### PR TITLE
fixing `Cannot use in operator` error when trying to read from a scope that is a string

### DIFF
--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -176,7 +176,7 @@ assign(Scope.prototype,{
 					currentReads = keyReads.slice(nameIndex);
 				},
 				earlyExit: function (parentValue, nameIndex) {
-					if (nameIndex > setObserveDepth || (nameIndex === setObserveDepth && (keyReads[nameIndex].key in parentValue) )) {
+					if (nameIndex > setObserveDepth || (nameIndex === setObserveDepth && (typeof parentValue === "object" && keyReads[nameIndex].key in parentValue) )) {
 						currentSetObserve = currentObserve;
 						currentSetReads = currentReads;
 						setObserveDepth = nameIndex;

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -386,3 +386,12 @@ test("trying to read constructor from refs scope is ok", function(){
 	construct.bind("change", function(){});
 	equal(construct(), ReferenceMap);
 });
+
+test("reading from a string in a nested scope doesn't throw an error (#22)",function(){
+	var foo = compute('foo');
+	var bar = compute('bar');
+	var scope = new Scope(foo);
+	var localScope = scope.add(bar);
+
+	equal(localScope.read('foo').value, undefined);
+});


### PR DESCRIPTION
Closes https://github.com/canjs/can-view-scope/issues/22.
