### PR TITLE
changing `peak` to `peek` and deprecating `peak`

### DIFF
--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -9,6 +9,7 @@ var makeComputeData = require('./compute_data');
 var assign = require('can-util/js/assign/assign');
 var each = require('can-util/js/each/each');
 var namespace = require('can-util/namespace');
+var dev = require('can-util/js/dev/dev');
 
 /**
  * @add can.view.Scope
@@ -255,8 +256,14 @@ assign(Scope.prototype,{
 		var res = this.read(key, options);
 		return res.value;
 	},
-	peak: Observation.ignore(function(key, options){
+	peek: Observation.ignore(function(key, options){
 		return this.get(key, options);
+	}),
+	peak: Observation.ignore(function(key, options){
+		//!steal-remove-start
+		dev.warn('peak is deprecated, please use peek instead');
+		//!steal-remove-end
+		return this.peek(key, options);
 	}),
 	// ## Scope.prototype.getScope
 	// Returns the first scope that passes the `tester` function.
@@ -338,7 +345,7 @@ assign(Scope.prototype,{
 	// ## Scope.prototype.attr
 	// Gets or sets a value in the scope without being observable.
 	attr: Observation.ignore(function (key, value, options) {
-		console.warn("can-view-scope::attr is deprecated, please use peak, get or set");
+		console.warn("can-view-scope::attr is deprecated, please use peek, get or set");
 
 		options = assign({
 			isArgument: true

--- a/docs/prototype.peek.md
+++ b/docs/prototype.peek.md
@@ -1,9 +1,9 @@
-@function can-view-scope.prototype.peak peak
+@function can-view-scope.prototype.peek peek
 @parent can-view-scope.prototype
 
 Read a value from the scope without being observable.
 
-@signature `scope.peak(key [, options])`
+@signature `scope.peek(key [, options])`
 
 Works just like [can-view-scope.prototype.get], but prevents any calls to [can-observation.add].
 
@@ -12,7 +12,7 @@ Walks up the scope to find a value at `key`.  Stops at the first context where `
 a value.
 
 ```js
-scope.peak("first.name");
+scope.peek("first.name");
 ```
 
 @param {can-stache.key} key A dot seperated path.  Use `"\."` if you have a
@@ -24,7 +24,7 @@ property name that includes a dot.
 
 ## Use
 
-`scope.peak(key)` looks up a value in the current scope's
+`scope.peek(key)` looks up a value in the current scope's
 context, if a value is not found, parent scope's context
 will be explored.
 
@@ -33,5 +33,5 @@ will be explored.
 
     var curScope = new Scope(list).add(justin);
 
-    curScope.peak("name"); //-> "Justin"
-    curScope.peak("length"); //-> 2
+    curScope.peek("name"); //-> "Justin"
+    curScope.peek("length"); //-> 2

--- a/test/scope-define-test.js
+++ b/test/scope-define-test.js
@@ -14,8 +14,8 @@ test("basics",function(){
 	var items = new DefineMap({ people: [{name: "Justin"},{name: "Brian"}], count: 1000 });
 
 	var itemsScope = new Scope(items),
-	arrayScope = new Scope(itemsScope.peak("people"), itemsScope),
-	firstItem = new Scope( arrayScope.peak('0'), arrayScope );
+	arrayScope = new Scope(itemsScope.peek("people"), itemsScope),
+	firstItem = new Scope( arrayScope.peek('0'), arrayScope );
 
 	var nameInfo;
 	var c = compute(function(){
@@ -50,9 +50,9 @@ test('backtrack path (#163)', function () {
 			format: 'str'
 		}, base = new Scope(row),
 		cur = base.add(col);
-	equal(cur.peak('.'), col, 'got col');
-	equal(cur.peak('..'), row, 'got row');
-	equal(cur.peak('../first'), 'Justin', 'got row');
+	equal(cur.peek('.'), col, 'got col');
+	equal(cur.peek('..'), row, 'got row');
+	equal(cur.peek('../first'), 'Justin', 'got row');
 });
 
 test('nested properties with compute', function () {

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -15,8 +15,8 @@ test("basics",function(){
 	var items = new Map({ people: [{name: "Justin"},[{name: "Brian"}]], count: 1000 });
 
 	var itemsScope = new Scope(items),
-	arrayScope = new Scope(itemsScope.peak('people'), itemsScope),
-	firstItem = new Scope( arrayScope.peak('0'), arrayScope );
+	arrayScope = new Scope(itemsScope.peek('people'), itemsScope),
+	firstItem = new Scope( arrayScope.peek('0'), arrayScope );
 
 	var nameInfo;
 	var c = compute(function(){
@@ -51,9 +51,9 @@ test('backtrack path (#163)', function () {
 			format: 'str'
 		}, base = new Scope(row),
 		cur = base.add(col);
-	equal(cur.peak('.'), col, 'got col');
-	equal(cur.peak('..'), row, 'got row');
-	equal(cur.peak('../first'), 'Justin', 'got row');
+	equal(cur.peek('.'), col, 'got col');
+	equal(cur.peek('..'), row, 'got row');
+	equal(cur.peek('../first'), 'Justin', 'got row');
 });
 
 test('nested properties with compute', function () {
@@ -351,7 +351,7 @@ test("A scope's %root is the last context", function(){
 	// the top.
 	var scope = refs.add(map).add(new Scope.Refs()).add(new Map());
 
-	var root = scope.peak("%root");
+	var root = scope.peek("%root");
 
 	ok(!(root instanceof Scope.Refs), "root isn't a reference");
 	equal(root, map, "The root is the map passed into the scope");
@@ -374,7 +374,7 @@ test("can read parent context with ../ (#2244)", function(){
 	var scope = new Scope(map);
 	var top = scope.add(new Map());
 
-	equal( top.peak("../"), map, "looked up value correctly");
+	equal( top.peek("../"), map, "looked up value correctly");
 
 });
 


### PR DESCRIPTION
Closes https://github.com/canjs/can-view-scope/issues/30.