### PR TITLE
compute_data uses the reflect API

### DIFF
--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -320,6 +320,8 @@ assign(Scope.prototype, {
 		return cur._context;
 	},
 	set: function(key, value, options) {
+		options = options || {};
+
 		// Use `.read` to read everything upto, but not including the last property name
 		// to find the object we want to set some property on.
 		// For example:

--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -375,7 +375,10 @@ assign(Scope.prototype, {
 		} else {
 			var context = this.read(contextPath, options).value;
 			if(!canReflect.isObservableLike(context) && canReflect.isObservableLike(context[propName])) {
-				dev.warn("can-view-scope: Merging " + propName + " into " + contextPath + " because its parent is non-observable");
+				dev.warn("can-view-scope: Merging data into \"" + propName + "\" because its parent is non-observable");
+				canReflect.eachKey(context[propName], function(value, prop) {
+					canReflect.deleteKeyValue(context[propName], prop);
+				});
 				canReflect.setValue(context[propName], value);
 			} else {
 				observeReader.write(context, propName, value, options);

--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -138,16 +138,12 @@ assign(Scope.prototype, {
 			}
 
 			if (isParentContext) {
-				return {
-					value: parent._context
-				};
+				return observeReader.read(parent._context, [], options);
 			}
 
 			return parent.read(attr.substr(3) || ".", options);
 		} else if (isCurrentContext) {
-			return {
-				value: this._context
-			};
+			return observeReader.read(this._context, [], options);
 		}
 		// if it's a reference scope, read from there.
 		var keyReads = observeReader.reads(attr);

--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -369,12 +369,17 @@ assign(Scope.prototype, {
 				propName = key;
 			}
 		}
-		
+
 		if (key.charAt(0) === "*") {
 			observeReader.write(this.getRefs()._context, key, value, options);
 		} else {
 			var context = this.read(contextPath, options).value;
-			observeReader.write(context, propName, value, options);
+			if(!canReflect.isObservableLike(context) && canReflect.isObservableLike(context[propName])) {
+				dev.warn("can-view-scope: Merging " + propName + " into " + contextPath + " because its parent is non-observable");
+				canReflect.setValue(context[propName], value);
+			} else {
+				observeReader.write(context, propName, value, options);
+			}
 		}
 	},
 

--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -375,10 +375,12 @@ assign(Scope.prototype, {
 		} else {
 			var context = this.read(contextPath, options).value;
 			if(!canReflect.isObservableLike(context) && canReflect.isObservableLike(context[propName])) {
-				dev.warn("can-view-scope: Merging data into \"" + propName + "\" because its parent is non-observable");
-				canReflect.eachKey(context[propName], function(value, prop) {
-					canReflect.deleteKeyValue(context[propName], prop);
-				});
+				if(canReflect.isMapLike(context[propName])) {
+					dev.warn("can-view-scope: Merging data into \"" + propName + "\" because its parent is non-observable");
+					canReflect.eachKey(context[propName], function(value, prop) {
+						canReflect.deleteKeyValue(context[propName], prop);
+					});
+				}
 				canReflect.setValue(context[propName], value);
 			} else {
 				observeReader.write(context, propName, value, options);

--- a/compute_data.js
+++ b/compute_data.js
@@ -7,6 +7,11 @@ var isFunction = require('can-util/js/is-function/is-function');
 var isEmptyObject = require('can-util/js/is-empty-object/is-empty-object');
 
 
+var canReflect = require('can-reflect');
+var canSymbol = require('can-symbol');
+
+
+
 // The goal of this is to create a high-performance compute that represents a key value from can.view.Scope.
 // If the key value is something like {{name}} and the context is a can.Map, a faster
 // binding path will be used where new rebindings don't need to be looked for with every change of
@@ -30,41 +35,158 @@ var isFastPath = function(computeData){
 	return;
 };
 
-var scopeReader = function(scope, key, options, computeData, newVal){
-	if (arguments.length > 4) {
-		var root = computeData.root || computeData.setRoot;
-		if(root) {
-			observeReader.write(root, computeData.reads, newVal, options);
-		} else {
-			scope.set(key, newVal, options);
-		}
-		// **Compute getter**
+
+// could we make this an observation first ... and have a getter for the compute?
+
+// This is a fast-path enabled Observation wrapper use many places in can-stache.
+// The goal of this is to:
+//
+// 1.  Make something that can be passed to can-view-live directly, hopefully
+//     avoiding creating expensive computes.  Instead we will only be creating
+//     `ScopeKeyData` which are thin wrappers.
+//
+// 2. Support the old "computeData" data type structure. If someone reads the
+//    .compute property, they will get a compute that behaves the same way.
+//
+// 3. We should begin eliminating creating computes in as many places as possible
+//    within CanJS code.  All of our helpers should be made to work with "faster"
+//    observable values: Observation -> ScopeKeyData -> Compute -> compute
+var ScopeKeyData = function(scope, key, options){
+	this.startingScope = scope;
+	this.key = key;
+	this.options = options;
+	this.observation = new Observation(this.read, this);
+	this.handlers = [];
+
+	// things added later
+	this.fastPath = undefined;
+	this.root = undefined;
+	this.initialValue = undefined;
+	this.reads = undefined;
+	this.setRoot = undefined;
+};
+ScopeKeyData.prototype.getValue = function(){
+	//Observation.add(this);
+	return this.observation.get();
+};
+// this is used by the Observation.
+// We use the observation for `getValue`
+ScopeKeyData.prototype.read = function(){
+	if (this.root) {
+		// if we've figured out a root observable, start reading from there
+		return observeReader.read(this.root, this.reads, this.options).value;
+	}
+	// If the key has not already been located in a observable then we need to search the scope for the
+	// key.  Once we find the key then we need to return it's value and if it is found in an observable
+	// then we need to store the observable so the next time this compute is called it can grab the value
+	// directly from the observable.
+	var data = this.startingScope.read(this.key, this.options);
+	this.scope = data.scope;
+	this.reads = data.reads;
+	this.root = data.rootObserve;
+	this.setRoot = data.setRoot;
+	return this.initialValue = data.value;
+};
+ScopeKeyData.prototype.setValue = function(newVal){
+	var root = this.root || this.setRoot;
+	if(root) {
+		observeReader.write(root, this.reads, newVal, this.options);
 	} else {
-		// If computeData has found the value for the key in the past in an observable then go directly to
-		// the observable (computeData.root) that the value was found in the last time and return the new value.  This
-		// is a huge performance gain for the fact that we aren't having to check the entire scope each time.
-		if (computeData.root) {
-			return observeReader.read(computeData.root, computeData.reads, options)
-				.value;
-		}
-		// If the key has not already been located in a observable then we need to search the scope for the
-		// key.  Once we find the key then we need to return it's value and if it is found in an observable
-		// then we need to store the observable so the next time this compute is called it can grab the value
-		// directly from the observable.
-		var data = scope.read(key, options);
-		computeData.scope = data.scope;
-		computeData.initialValue = data.value;
-		computeData.reads = data.reads;
-		computeData.root = data.rootObserve;
-		computeData.setRoot = data.setRoot;
-		return data.value;
+		this.startingScope.set(this.key, newVal, this.options);
 	}
 };
+
+var canOnValue = canSymbol.for("can.onValue"),
+	canOffValue = canSymbol.for("can.offValue");
+canReflect.set(ScopeKeyData.prototype, canOnValue, function(handler){
+	if(!this.handlers.length) {
+		canReflect.onValue(this.observation, this.dispatch.bind(this));
+		// TODO: we should check this sometime in the background.
+		if( isFastPath(this) ) {
+			// rewrite the observation to call its event handlers
+
+			var self = this,
+				observation = this.observation;
+
+			this.fastPath = true;
+			// there won't be an event in the future ...
+			observation.dependencyChange = function(ev, newVal){
+				// but I think we will be able to get at it b/c there should only be one
+				// dependency we are binding to ...
+				if(types.isMapLike(ev.target) && typeof newVal !== "function") {
+					this.newVal = newVal;
+				} else {
+					// restore
+					observation.dependencyChange = Observation.prototype.dependencyChange;
+					observation.start = Observation.prototype.start;
+					self.fastPath = false;
+				}
+
+				return Observation.prototype.dependencyChange.call(this, ev);
+			};
+			observation.start = function(){
+				this.value = this.newVal;
+			};
+
+		}
+	}
+	this.handlers.push(handler);
+});
+
+ScopeKeyData.prototype.dispatch = function(){
+	var handlers = this.handlers.slice(0);
+	for(var i = 0, len = handlers.length; i < len; i++) {
+		handlers[i].apply(this, arguments);
+	}
+};
+
+canReflect.set(ScopeKeyData.prototype, canOffValue, function(handler){
+	var index = this.handlers.indexOf(handler);
+	this.handlers.splice(index, 1);
+});
+
+canReflect.set(ScopeKeyData.prototype, canSymbol.for("can.getValue"), function(handler){
+	return this.observation.get();
+});
+
+canReflect.set(ScopeKeyData.prototype, canSymbol.for("can.setValue"), ScopeKeyData.prototype.getValue);
+
+
+// once a compute is read, cache it
+Object.defineProperty(ScopeKeyData.prototype,"compute",{
+	get: function(){
+		var scopeKeyData = this;
+		var compute = makeCompute(undefined,{
+			on: function(updater) {
+				scopeKeyData[canOnValue](updater);
+				// this uses a lot of inside knowledge
+				this.value = scopeKeyData.observation.value;
+			},
+			off: function(updater){
+				scopeKeyData[canOffValue](updater);
+			},
+			get: function(){
+				return scopeKeyData.observation.get();
+			},
+			set: function(newValue){
+				return scopeKeyData.setValue(newValue);
+			}
+		});
+		this.compute = compute;
+		return compute;
+	}
+});
+
+
+
+
 
 module.exports = function(scope, key, options){
 	options = options || {
 		args: []
 	};
+	return new ScopeKeyData(scope, key, options);
+	/*
 	// the object we are returning
 	var computeData = {},
 		// a function that can be passed to Observation, or used as a setter
@@ -114,9 +236,13 @@ module.exports = function(scope, key, options){
 		}),
 
 		// the observables read by the last calling of `scopeRead`
-		observation = new Observation(scopeRead, null, compute.computeInstance);
+
 	compute.computeInstance.observation = observation;
+
+	computeData.observation = new Observation(scopeRead);
+
+
 	computeData.compute = compute;
-	return computeData;
+	return computeData;*/
 
 };

--- a/compute_data.js
+++ b/compute_data.js
@@ -3,10 +3,7 @@ var Observation = require('can-observation');
 var observeReader = require('can-observation/reader/reader');
 var makeCompute = require('can-compute');
 var assign = require('can-util/js/assign/assign');
-
-var types = require('can-types');
 var isFunction = require('can-util/js/is-function/is-function');
-
 var canBatch = require('can-event/batch/batch');
 var CID = require("can-cid");
 var canReflect = require('can-reflect');
@@ -29,15 +26,15 @@ var canSymbol = require('can-symbol');
 // If the `this` is not that object ... freak out.  Though `this` is not necessarily part of it.  can-observation could make
 // this work.
 var getFastPathRoot = function(computeData){
-	if(  computeData.reads &&
+	if( computeData.reads &&
 				// a single property read
 				computeData.reads.length === 1 ) {
 		var root = computeData.root;
-		if( types.isCompute(root) ) {
+		if( root && root[canSymbol.for("can.getValue")] ) {
 			root = canReflect.getValue(root);
 		}
 		// on a map
-		return types.isMapLike(root) &&
+		return root && canReflect.isObservableLike(root) && canReflect.isMapLike(root) &&
 			// that isn't calling a function
 			!isFunction(root[computeData.reads[0].key]) && root;
 	}

--- a/compute_data.js
+++ b/compute_data.js
@@ -65,8 +65,10 @@ var ScopeKeyData = function(scope, key, options){
 	this.reads = undefined;
 	this.setRoot = undefined;
 };
+// This isn't working right yet.  It's working b/c it's falling through.
+// The observation isn't bound for some reason.
 ScopeKeyData.prototype.getValue = function(){
-	//Observation.add(this);
+	Observation.add(this);
 	return this.observation.get();
 };
 // this is used by the Observation.

--- a/compute_data.js
+++ b/compute_data.js
@@ -1,3 +1,4 @@
+"use strict";
 var Observation = require('can-observation');
 var observeReader = require('can-observation/reader/reader');
 var makeCompute = require('can-compute');
@@ -106,6 +107,9 @@ ScopeKeyData.prototype.setValue = function(newVal){
 		this.startingScope.set(this.key, newVal, this.options);
 	}
 };
+ScopeKeyData.prototype.hasDependencies = function(){
+	return this.observation.hasDependencies();
+};
 
 var canOnValue = canSymbol.for("can.onValue"),
 	canOffValue = canSymbol.for("can.offValue");
@@ -166,6 +170,9 @@ canReflect.set(ScopeKeyData.prototype, canSymbol.for("can.getValue"), function(h
 
 canReflect.set(ScopeKeyData.prototype, canSymbol.for("can.setValue"), ScopeKeyData.prototype.getValue);
 
+canReflect.set(ScopeKeyData.prototype, canSymbol.for("can.valueHasDependencies"), ScopeKeyData.prototype.hasDependencies);
+
+
 
 // once a compute is read, cache it
 Object.defineProperty(ScopeKeyData.prototype,"compute",{
@@ -187,9 +194,14 @@ Object.defineProperty(ScopeKeyData.prototype,"compute",{
 				return scopeKeyData.setValue(newValue);
 			}
 		});
-		this.compute = compute;
+		Object.defineProperty(this, "compute", {
+			value: compute,
+			writable: false,
+			configurable: false
+		});
 		return compute;
-	}
+	},
+	configurable: true
 });
 
 

--- a/compute_data.js
+++ b/compute_data.js
@@ -198,7 +198,10 @@ Object.defineProperty(ScopeKeyData.prototype,"compute",{
 				return scopeKeyData.setValue(newValue);
 			}
 		});
-		compute.computeInstance._observation = this.observation;
+		// this is important so it will always call observation.get
+		// This is something that should be "fixed" somehow for everything
+		// related to observations.
+		compute.computeInstance.observation = this.observation;
 		Object.defineProperty(this, "compute", {
 			value: compute,
 			writable: false,

--- a/compute_data.js
+++ b/compute_data.js
@@ -6,6 +6,7 @@ var makeCompute = require('can-compute');
 var types = require('can-types');
 var isFunction = require('can-util/js/is-function/is-function');
 
+var canBatch = require('can-event/batch/batch');
 var CID = require("can-cid");
 var canReflect = require('can-reflect');
 var canSymbol = require('can-symbol');
@@ -162,6 +163,7 @@ canReflect.set(ScopeKeyData.prototype, canOnValue, function(handler){
 ScopeKeyData.prototype.dispatch = function(){
 	var handlers = this.handlers.slice(0);
 	for(var i = 0, len = handlers.length; i < len; i++) {
+		canBatch.batchNum = this.observation.batchNum;
 		handlers[i].apply(this, arguments);
 	}
 };

--- a/compute_data.js
+++ b/compute_data.js
@@ -2,6 +2,7 @@
 var Observation = require('can-observation');
 var observeReader = require('can-observation/reader/reader');
 var makeCompute = require('can-compute');
+var assign = require('can-util/js/assign/assign');
 
 var types = require('can-types');
 var isFunction = require('can-util/js/is-function/is-function');
@@ -67,8 +68,8 @@ var ScopeKeyData = function(scope, key, options){
 	CID(this);
 	this.startingScope = scope;
 	this.key = key;
-	this.options = options;
 	this.observation = new Observation(this.read, this);
+	this.options = assign({ observation: this.observation }, options);
 	this.handlers = [];
 	this.dispatchHandler = this.dispatch.bind(this);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-view-scope",
-  "version": "3.1.4",
+  "version": "3.2.0-pre.0",
   "description": "Observable scopes",
   "homepage": "http://canjs.com",
   "repository": {
@@ -15,11 +15,11 @@
   "scripts": {
     "preversion": "npm test && npm run build",
     "version": "git commit -am \"Update dist for release\" && git checkout -b release && git add -f dist/",
-    "postversion": "git push --tags && git checkout master && git branch -D release && git push",
+    "postversion": "git push --tags && git checkout can-reflect && git branch -D release && git push origin can-reflect",
     "testee": "testee test/test.html --browsers firefox",
     "test": "npm run jshint && npm run testee",
     "jshint": "jshint ./*.js --config",
-    "release:pre": "npm version prerelease && npm publish",
+    "release:pre": "npm version prerelease && npm publish --tag pre",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
@@ -34,20 +34,20 @@
     "donejs"
   ],
   "dependencies": {
-    "can-compute": "^3.0.0",
+    "can-compute": "^3.1.0-pre.1",
     "can-construct": "^3.0.0",
-    "can-list": "^3.0.0",
     "can-namespace": "1.0.0",
-    "can-observation": "^3.0.1",
-    "can-simple-map": "^3.0.0",
+    "can-observation": "^3.2.0-pre.5",
+    "can-simple-map": "^3.1.4-pre.1",
     "can-types": "^1.0.1",
     "can-util": "^3.2.2",
-	"can-reflect": "^0.0.0",
-	"can-symbol": "^0.0.0"
+	"can-reflect": "^0.0.1",
+	"can-symbol": "^0.0.1"
   },
   "devDependencies": {
-    "can-map": "^3.0.0",
-    "can-define": "^1.0.1",
+	"can-list": "^3.0.4-pre.1",
+    "can-map": "^3.0.7-pre.1",
+    "can-define": "^1.2.0-pre.1",
     "bit-docs": "0.0.7",
     "jshint": "^2.9.1",
     "steal": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "can-event": "^3.0.0",
     "can-namespace": "1.0.0",
     "can-observation": "^3.2.0-pre.6",
-    "can-reflect": "0.0.2",
+    "can-reflect": "0.0.3",
     "can-simple-map": "^3.2.0-pre.0",
     "can-symbol": "0.0.3",
     "can-types": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-view-scope",
-  "version": "3.2.0-pre.10",
+  "version": "3.2.0-pre.11",
   "description": "Observable scopes",
   "homepage": "http://canjs.com",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-view-scope",
-  "version": "3.2.0-pre.1",
+  "version": "3.2.0-pre.2",
   "description": "Observable scopes",
   "homepage": "http://canjs.com",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-view-scope",
-  "version": "3.2.0-pre.0",
+  "version": "3.2.0-pre.1",
   "description": "Observable scopes",
   "homepage": "http://canjs.com",
   "repository": {
@@ -41,11 +41,11 @@
     "can-simple-map": "^3.1.4-pre.1",
     "can-types": "^1.0.1",
     "can-util": "^3.2.2",
-	"can-reflect": "^0.0.1",
-	"can-symbol": "^0.0.1"
+    "can-reflect": "^0.0.1",
+    "can-symbol": "^0.0.1"
   },
   "devDependencies": {
-	"can-list": "^3.0.4-pre.1",
+    "can-list": "^3.0.4-pre.1",
     "can-map": "^3.0.7-pre.1",
     "can-define": "^1.2.0-pre.1",
     "bit-docs": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-view-scope",
-  "version": "3.2.0-pre.9",
+  "version": "3.2.0-pre.10",
   "description": "Observable scopes",
   "homepage": "http://canjs.com",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "can-namespace": "1.0.0",
     "can-observation": "^3.2.0-pre.6",
     "can-reflect": "0.0.3",
-    "can-simple-map": "^3.2.0-pre.0",
+    "can-simple-map": "^3.2.0-pre.2",
     "can-symbol": "0.0.3",
     "can-types": "^1.0.1",
     "can-util": "^3.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-view-scope",
-  "version": "3.2.0-pre.6",
+  "version": "3.2.0-pre.7",
   "description": "Observable scopes",
   "homepage": "http://canjs.com",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "can-cid": "^1.0.3",
-    "can-compute": "^3.1.0-pre.3",
+    "can-compute": "^3.1.0-pre.7",
     "can-construct": "^3.0.0",
     "can-event": "^3.0.0",
     "can-namespace": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-view-scope",
-  "version": "3.2.0-pre.8",
+  "version": "3.2.0-pre.9",
   "description": "Observable scopes",
   "homepage": "http://canjs.com",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -37,14 +37,14 @@
     "can-cid": "^1.0.3",
     "can-compute": "^3.1.0-pre.3",
     "can-construct": "^3.0.0",
+    "can-event": "^3.0.0",
     "can-namespace": "1.0.0",
     "can-observation": "^3.2.0-pre.6",
     "can-reflect": "0.0.2",
     "can-simple-map": "^3.2.0-pre.0",
     "can-symbol": "0.0.3",
     "can-types": "^1.0.1",
-    "can-util": "^3.2.2",
-    "can-event": "^3.0.0"
+    "can-util": "^3.2.2"
   },
   "devDependencies": {
     "can-list": "^3.1.0-pre.1",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "can-event": "^3.0.0",
     "can-namespace": "1.0.0",
     "can-observation": "^3.2.0-pre.10",
-    "can-reflect": "0.0.3",
+    "can-reflect": "^1.0.0-pre.1",
     "can-simple-map": "^3.2.0-pre.2",
-    "can-symbol": "0.0.3",
+    "can-symbol": "^1.0.0-pre.0",
     "can-types": "^1.0.1",
     "can-util": "^3.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-view-scope",
-  "version": "3.2.0-pre.4",
+  "version": "3.2.0-pre.5",
   "description": "Observable scopes",
   "homepage": "http://canjs.com",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "can-cid": "^1.0.3",
     "can-compute": "^3.1.0-pre.7",
-    "can-construct": "^3.0.0",
+    "can-construct": "^3.2.0-pre.0",
     "can-event": "^3.5.0-pre.2",
     "can-namespace": "1.0.0",
     "can-observation": "^3.2.0-pre.10",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "can-construct": "^3.0.0",
     "can-event": "^3.0.0",
     "can-namespace": "1.0.0",
-    "can-observation": "^3.2.0-pre.6",
+    "can-observation": "^3.2.0-pre.10",
     "can-reflect": "0.0.3",
     "can-simple-map": "^3.2.0-pre.2",
     "can-symbol": "0.0.3",
@@ -47,18 +47,18 @@
     "can-util": "^3.2.2"
   },
   "devDependencies": {
-    "can-list": "^3.1.0-pre.1",
-    "can-map": "^3.1.0-pre.2",
-    "can-define": "^1.2.0-pre.1",
     "bit-docs": "0.0.7",
+    "can-define": "^1.2.0-pre.3",
+    "can-list": "^3.1.0-pre.7",
+    "can-map": "^3.1.0-pre.8",
+    "done-serve": "^0.2.0",
+    "donejs-cli": "^0.9.5",
+    "generator-donejs": "^0.9.0",
     "jshint": "^2.9.1",
     "steal": "^1.0.1",
     "steal-qunit": "^1.0.0",
     "steal-tools": "^1.0.0",
-    "testee": "^0.3.0",
-    "generator-donejs": "^0.9.0",
-    "donejs-cli": "^0.9.5",
-    "done-serve": "^0.2.0"
+    "testee": "^0.3.0"
   },
   "bit-docs": {
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
     "can-construct": "^3.0.0",
     "can-namespace": "1.0.0",
     "can-observation": "^3.2.0-pre.5",
+    "can-reflect": "0.0.1",
     "can-simple-map": "^3.1.4-pre.1",
+    "can-symbol": "0.0.1",
     "can-types": "^1.0.1",
-    "can-util": "^3.2.2",
-    "can-reflect": "^0.0.1",
-    "can-symbol": "^0.0.1"
+    "can-util": "^3.2.2"
   },
   "devDependencies": {
     "can-list": "^3.0.4-pre.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "can-compute": "^3.1.0-pre.3",
     "can-construct": "^3.0.0",
     "can-namespace": "1.0.0",
-    "can-observation": "^3.2.0-pre.5",
+    "can-observation": "^3.2.0-pre.6",
     "can-reflect": "0.0.1",
     "can-simple-map": "^3.1.4-pre.1",
     "can-symbol": "0.0.1",
@@ -47,7 +47,7 @@
     "can-event": "^3.0.0"
   },
   "devDependencies": {
-    "can-list": "^3.1.0-pre.1",
+	"can-list": "^3.1.0-pre.1",
     "can-map": "^3.1.0-pre.2",
     "can-define": "^1.2.0-pre.1",
     "bit-docs": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -37,14 +37,14 @@
     "can-cid": "^1.0.3",
     "can-compute": "^3.1.0-pre.7",
     "can-construct": "^3.0.0",
-    "can-event": "^3.0.0",
+    "can-event": "^3.5.0-pre.2",
     "can-namespace": "1.0.0",
     "can-observation": "^3.2.0-pre.10",
     "can-reflect": "^1.0.0-pre.1",
     "can-simple-map": "^3.2.0-pre.2",
     "can-symbol": "^1.0.0-pre.0",
-    "can-types": "^1.0.1",
-    "can-util": "^3.2.2"
+    "can-types": "^1.1.0-pre.2",
+    "can-util": "^3.9.0-pre.4"
   },
   "devDependencies": {
     "bit-docs": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-view-scope",
-  "version": "3.2.0-pre.12",
+  "version": "3.2.0-pre.13",
   "description": "Observable scopes",
   "homepage": "http://canjs.com",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "donejs"
   ],
   "dependencies": {
-    "can-compute": "^3.1.0-pre.1",
+    "can-cid": "^1.0.3",
+    "can-compute": "^3.1.0-pre.3",
     "can-construct": "^3.0.0",
     "can-namespace": "1.0.0",
     "can-observation": "^3.2.0-pre.5",
@@ -42,11 +43,12 @@
     "can-simple-map": "^3.1.4-pre.1",
     "can-symbol": "0.0.1",
     "can-types": "^1.0.1",
-    "can-util": "^3.2.2"
+    "can-util": "^3.2.2",
+    "can-event": "^3.0.0"
   },
   "devDependencies": {
-    "can-list": "^3.0.4-pre.1",
-    "can-map": "^3.0.7-pre.1",
+    "can-list": "^3.1.0-pre.1",
+    "can-map": "^3.1.0-pre.2",
     "can-define": "^1.2.0-pre.1",
     "bit-docs": "0.0.7",
     "jshint": "^2.9.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "can-reflect": "^1.0.0-pre.1",
     "can-simple-map": "^3.2.0-pre.2",
     "can-symbol": "^1.0.0-pre.0",
-    "can-types": "^1.1.0-pre.2",
     "can-util": "^3.9.0-pre.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-view-scope",
-  "version": "3.2.0-pre.3",
+  "version": "3.2.0-pre.4",
   "description": "Observable scopes",
   "homepage": "http://canjs.com",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-view-scope",
-  "version": "3.2.0-pre.2",
+  "version": "3.2.0-pre.3",
   "description": "Observable scopes",
   "homepage": "http://canjs.com",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "can-observation": "^3.0.1",
     "can-simple-map": "^3.0.0",
     "can-types": "^1.0.1",
-    "can-util": "^3.2.2"
+    "can-util": "^3.2.2",
+	"can-reflect": "^0.0.0",
+	"can-symbol": "^0.0.0"
   },
   "devDependencies": {
     "can-map": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-view-scope",
-  "version": "3.2.0-pre.7",
+  "version": "3.2.0-pre.8",
   "description": "Observable scopes",
   "homepage": "http://canjs.com",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-view-scope",
-  "version": "3.2.0-pre.11",
+  "version": "3.2.0-pre.12",
   "description": "Observable scopes",
   "homepage": "http://canjs.com",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-view-scope",
-  "version": "3.2.0-pre.5",
+  "version": "3.2.0-pre.6",
   "description": "Observable scopes",
   "homepage": "http://canjs.com",
   "repository": {
@@ -47,7 +47,7 @@
     "can-event": "^3.0.0"
   },
   "devDependencies": {
-	"can-list": "^3.1.0-pre.1",
+    "can-list": "^3.1.0-pre.1",
     "can-map": "^3.1.0-pre.2",
     "can-define": "^1.2.0-pre.1",
     "bit-docs": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "can-construct": "^3.0.0",
     "can-namespace": "1.0.0",
     "can-observation": "^3.2.0-pre.6",
-    "can-reflect": "0.0.1",
-    "can-simple-map": "^3.1.4-pre.1",
-    "can-symbol": "0.0.1",
+    "can-reflect": "0.0.2",
+    "can-simple-map": "^3.2.0-pre.0",
+    "can-symbol": "0.0.3",
     "can-types": "^1.0.1",
     "can-util": "^3.2.2",
     "can-event": "^3.0.0"

--- a/reference-map.js
+++ b/reference-map.js
@@ -1,15 +1,6 @@
-var types = require("can-types");
 var SimpleMap = require("can-simple-map");
 
 // this is a very simple can-map like object
 var ReferenceMap = SimpleMap.extend({});
-
-var oldIsMapLike = types.isMapLike;
-types.isMapLike = function(obj) {
-	if(obj instanceof ReferenceMap) {
-		return true;
-	}
-	return oldIsMapLike.call(this, obj);
-};
 
 module.exports = ReferenceMap;

--- a/test/scope-define-test.js
+++ b/test/scope-define-test.js
@@ -48,7 +48,8 @@ test('backtrack path (#163)', function () {
 	}),
 		col = {
 			format: 'str'
-		}, base = new Scope(row),
+		},
+		base = new Scope(row),
 		cur = base.add(col);
 	equal(cur.peek('.'), col, 'got col');
 	equal(cur.peek('..'), row, 'got row');

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -401,27 +401,27 @@ test("Optimize for compute().observableProperty (#29)", function(){
 	var wrap = compute(map);
 
 	var scope = new Scope(wrap);
-
-	var scopeCompute = scope.compute("value");
+	var scopeKeyData = scope.computeData("value");
+	var scopeCompute = scopeKeyData.compute;
 
 	var changeNumber = 0;
 	scopeCompute.on("change", function(ev, newVal, oldVal){
 		if(changeNumber === 1) {
 			QUnit.equal(newVal, "b");
 			QUnit.equal(oldVal, "a");
-			QUnit.ok(scopeCompute.fastPath, "still fast path");
+			QUnit.ok(scopeKeyData.fastPath, "still fast path");
 			changeNumber++;
 			wrap(new Map({value: "c"}));
 		} else if(changeNumber === 2) {
 			QUnit.equal(newVal, "c", "got new value");
 			QUnit.equal(oldVal, "b", "got old value");
-			QUnit.notOk(scopeCompute.fastPath, "still fast path");
+			QUnit.notOk(scopeKeyData.fastPath, "still fast path");
 		}
 
 	});
 
 
-	QUnit.ok(scopeCompute.fastPath, "fast path");
+	QUnit.ok(scopeKeyData.fastPath, "fast path");
 
 	changeNumber++;
 	map.attr("value", "b");
@@ -431,4 +431,21 @@ test("read should support passing %scope (#24)", function() {
 	var scope = new Scope(new Map({ foo: "", bar: "" }));
 
 	equal(scope.read("%scope").value, scope, "looked up %scope correctly");
+});
+
+
+test("a compute can observe the ScopeKeyData", function(){
+	var map = new Map({value: "a", other: "b"});
+	var wrap = compute(map);
+
+	var scope = new Scope(wrap);
+	var scopeKeyData = scope.computeData("value");
+
+	var c = compute(function(){
+		return scopeKeyData.getValue() + map.attr("other");
+	});
+
+	c.on("change", function(ev, newValue){
+
+	});
 });

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -446,6 +446,8 @@ test("a compute can observe the ScopeKeyData", function(){
 	});
 
 	c.on("change", function(ev, newValue){
-
+		QUnit.equal(newValue,"Ab");
 	});
+
+	map.attr("value","A");
 });

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -475,3 +475,13 @@ QUnit.asyncTest("unbinding clears all event bindings", function(){
 		start();
 	}, 30);
 });
+
+QUnit.test("computes are read as this and . and  ../", function(){
+	var value = compute(1);
+	var scope = new Scope(value);
+	QUnit.equal(scope.get("this"), 1, "this read value");
+	QUnit.equal(scope.get("this"), 1, ". read value");
+	scope = scope.add({});
+
+	QUnit.equal(scope.get(".."), 1, ".. read value");
+});

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -451,3 +451,27 @@ test("a compute can observe the ScopeKeyData", function(){
 
 	map.attr("value","A");
 });
+
+QUnit.asyncTest("unbinding clears all event bindings", function(){
+	var map = new Map({value: "a", other: "b"});
+	var wrap = compute(map);
+
+	var scope = new Scope(wrap);
+	var scopeKeyData = scope.computeData("value");
+
+	var c = compute(function(){
+		return scopeKeyData.getValue() + map.attr("other");
+	});
+
+	var handlers = function(ev, newValue){
+		QUnit.equal(newValue,"Ab");
+	};
+	c.on("change", handlers);
+
+	c.off("change", handlers);
+
+	setTimeout(function () {
+		equal(map._bindings, 0, "there are no bindings");
+		start();
+	}, 30);
+});

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -509,6 +509,15 @@ QUnit.test("computes are set as this and . and  ../", function(){
 	QUnit.equal(scope.get(".."), 4, ".. read value");
 });
 
+QUnit.test("maps are set with this.foo and ./foo", function(){
+	var map = compute(new Map({value: 1}));
+	var scope = new Scope(map);
+	scope.set("this.value",2);
+	QUnit.equal(scope.get("this.value"), 2, "this read value");
+	scope.set("./value",3);
+	QUnit.equal(scope.get("./value"), 3, ". read value");
+});
+
 QUnit.test("scopeKeyData fires during batch", function(){
 	var map = new Map({value: "a", other: "b"});
 


### PR DESCRIPTION
This rewrites compute_data as `ScopeKeyData`.  It maintains the same properties and values that were provided, but does it by creating a constructor function that is a thin wrapper over Observation.

This thin wrapper is hopefully what will be used everywhere internally in stache instead of computes.  

Related: https://github.com/canjs/can-observation/pull/72