### PR TITLE
chore(package): update can-define to version 1.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "can-stache-key": "0.0.3"
   },
   "devDependencies": {
-    "can-define": "^1.3.0",
+    "can-define": "^1.3.3",
     "can-list": "^3.2.0",
     "can-map": "^3.3.1",
     "jshint": "^2.9.1",


### PR DESCRIPTION
Fixes #61 