### PR TITLE
55 reference scope throw

### DIFF
--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -298,9 +298,16 @@ assign(Scope.prototype, {
 	// Used by `.read` when looking up `*key` and by the references
 	// view binding.
 	getRefs: function() {
-		return this.getScope(function(scope) {
+		var lastScope;
+		var refScope = this.getScope(function(scope) {
+			lastScope = scope;
 			return scope._context instanceof Scope.Refs;
 		});
+		if(!refScope) {
+			lastScope._parent = new Scope.Refs();
+			refScope = lastScope._parent;
+		}
+		return refScope;
 	},
 	// ## Scope.prototype.getRoot
 	// Returns the top most context that is not a references scope.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "can-define": "^1.3.3",
     "can-list": "^3.2.0",
     "can-map": "^3.3.1",
+    "can-stache": "^3.3.3",
     "jshint": "^2.9.1",
     "steal": "^1.0.1",
     "steal-qunit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "can-define": "^1.3.3",
     "can-list": "^3.2.0",
     "can-map": "^3.3.1",
-    "can-stache": "^3.3.3",
     "jshint": "^2.9.1",
     "steal": "^1.0.1",
     "steal-qunit": "^1.0.0",

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -596,8 +596,24 @@ QUnit.test("scopeKeyData offValue resets dependencyChange/start", function() {
 });
 
 QUnit.test("Rendering a template with a custom scope (#55)", function() {
-	var scope = new Scope({});
+	var scope = new Scope({}),
+		scopeRefs;
 	
+	try {
+		scopeRefs = scope.getRefs();
+		scopeRefs._read;
+		QUnit.ok(true, "Did not throw");
+	}
+	catch(e) {
+		QUnit.ok(false, e.message);
+	}
+
+	QUnit.equal(scope.get('name'), undefined, "No name");
+	scope.set('name', 'John');
+	QUnit.equal(scope.get('name'), 'John', "Got the name");
+	scope = scope.add({name: 'Justin'});
+	QUnit.equal(scope.get('name'), 'Justin', "Got the top scope name");
+
 	try {
 		var scopeRefs = scope.getRefs();
 		scopeRefs._read;

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -6,7 +6,6 @@ var observeReader = require('can-stache-key');
 var compute = require('can-compute');
 var ReferenceMap = require('../reference-map');
 var canSymbol = require("can-symbol");
-var stache = require('can-stache');
 
 var QUnit = require('steal-qunit');
 var canBatch = require("can-event/batch/batch");
@@ -599,23 +598,12 @@ QUnit.test("scopeKeyData offValue resets dependencyChange/start", function() {
 QUnit.test("Rendering a template with a custom scope (#55)", function() {
 	var scope = new Scope({});
 	
-	
-	var template = stache('<foo-bar {^.}="*bar" />{{*bar.foo}}');
-	scope = scope.add( new Scope.Refs() ); // works with custom scope
 	try {
-		template(scope); // throws "Cannot read property '_read' of undefined"
-		QUnit.ok(true, "Did not throw error");
+		var scopeRefs = scope.getRefs();
+		scopeRefs._read;
+		QUnit.ok(true, "Did not throw");
 	}
 	catch(e) {
 		QUnit.ok(false, e.message);
 	}
-	
-	// try {
-	// 	var scopeRefs = scope.getRefs();
-	// 	scopeRefs._read;
-	// 	QUnit.ok(true, "Did not throw");
-	// }
-	// catch(e) {
-	// 	QUnit.ok(false, e.message);
-	// }
 });

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -6,6 +6,7 @@ var observeReader = require('can-stache-key');
 var compute = require('can-compute');
 var ReferenceMap = require('../reference-map');
 var canSymbol = require("can-symbol");
+var stache = require('can-stache');
 
 var QUnit = require('steal-qunit');
 var canBatch = require("can-event/batch/batch");
@@ -593,4 +594,28 @@ QUnit.test("scopeKeyData offValue resets dependencyChange/start", function() {
 
 	QUnit.equal(scopeKeyData.observation.dependencyChange, Observation.prototype.dependencyChange, 'dependencyChange should be restored');
 	QUnit.equal(scopeKeyData.observation.start, Observation.prototype.start, 'start should be restored');
+});
+
+QUnit.test("Rendering a template with a custom scope (#55)", function() {
+	var scope = new Scope({});
+	
+	
+	var template = stache('<foo-bar {^.}="*bar" />{{*bar.foo}}');
+	scope = scope.add( new Scope.Refs() ); // works with custom scope
+	try {
+		template(scope); // throws "Cannot read property '_read' of undefined"
+		QUnit.ok(true, "Did not throw error");
+	}
+	catch(e) {
+		QUnit.ok(false, e.message);
+	}
+	
+	// try {
+	// 	var scopeRefs = scope.getRefs();
+	// 	scopeRefs._read;
+	// 	QUnit.ok(true, "Did not throw");
+	// }
+	// catch(e) {
+	// 	QUnit.ok(false, e.message);
+	// }
 });


### PR DESCRIPTION
When calling `scope.getRefs()` if no references scope is found add one as the top scope's parent and return it.

For #55 