### PR TITLE
Display warning, but also handle scope in scope as best we can

### DIFF
--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -81,9 +81,20 @@ assign(Scope.prototype, {
 	// scope.attr("name") //-> "Brian"
 	// ```
 	add: function(context, meta) {
-		if (context !== this._context) {
+		var isScope = context.constructor === this.constructor;
+		//!steal-remove-start
+		if (isScope) {
+			dev.warn("Adding a scope to a scope with scope.add() is not supported. Use 'scope = new Scope(context, parentScope)' instead.");
+		}
+		//!steal-remove-end
+
+		if (context !== this._context && !isScope) {
 			return new this.constructor(context, this, meta);
-		} else {
+		}
+		else if (context._context) {
+			return new this.constructor(context._context, this, meta);
+		}
+		else {
 			return this;
 		}
 	},

--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -81,7 +81,7 @@ assign(Scope.prototype, {
 	// scope.attr("name") //-> "Brian"
 	// ```
 	add: function(context, meta) {
-		var isScope = context.constructor === this.constructor;
+		var isScope = context ? context.constructor === this.constructor : false;
 		//!steal-remove-start
 		if (isScope) {
 			dev.warn("Adding a scope to a scope with scope.add() is not supported. Use 'scope = new Scope(context, parentScope)' instead.");
@@ -91,7 +91,7 @@ assign(Scope.prototype, {
 		if (context !== this._context && !isScope) {
 			return new this.constructor(context, this, meta);
 		}
-		else if (context._context) {
+		else if (isScope && context._context) {
 			return new this.constructor(context._context, this, meta);
 		}
 		else {


### PR DESCRIPTION
Made tests and added a warning when someone tries to add a scope to a scope with `scope.add()` like:
```
var scope = new Scope();
var parentScope = new Scope();
scope = scope.add(parentScope);
```
Also try to gracefully handle it by taking the `_context` of the scope passed into `scope.add()` instead of the scope itself.

Not sure if we want to do this or just throw an error.

For https://github.com/canjs/canjs/issues/3462