### PR TITLE
Make generated refs scope a Scope

### DIFF
--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -305,7 +305,7 @@ assign(Scope.prototype, {
 			return scope._context instanceof Scope.Refs;
 		});
 		if(!refScope) {
-			lastScope._parent = new Scope.Refs();
+			lastScope._parent = Scope.refsScope();
 			refScope = lastScope._parent;
 		}
 		return refScope;

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -615,11 +615,23 @@ QUnit.test("Rendering a template with a custom scope (#55)", function() {
 	QUnit.equal(scope.get('name'), 'Justin', "Got the top scope name");
 
 	try {
-		var scopeRefs = scope.getRefs();
+		scopeRefs = scope.getRefs();
 		scopeRefs._read;
 		QUnit.ok(true, "Did not throw");
 	}
 	catch(e) {
 		QUnit.ok(false, e.message);
 	}
+});
+
+
+QUnit.test("generated refs scope is a Scope", function() {
+
+	var scope = new Scope({});
+	QUnit.equal(scope._parent, undefined, "scope initially has no parent");
+	var refScope = scope.getRefs();
+
+	QUnit.ok(refScope instanceof Scope, "refScope is a scope");
+	QUnit.ok(refScope._context instanceof Scope.Refs, "refScope context is a refs object");
+	QUnit.equal(scope._parent, refScope, "refScope is a parent of scope");
 });


### PR DESCRIPTION
A Refs scope can be generated by `Scope.prototype.getRefs()` if it doesn't currently exist on the scope chain.  However, it was incorrectly generated to be a Scope.Refs object (which should be the scope context, not the scope itself).  This PR uses Scope.refsScope() to create a new Refs Scope when generating one in getRefs()