### PR TITLE
expanding refsScope to be accessible through scope.vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "can-cid": "^1.0.3",
     "can-compute": "^3.3.7",
     "can-construct": "^3.2.0",
+    "can-define-lazy-value": "^1.0.0",
     "can-event": "^3.5.0",
     "can-log": "^0.1.0",
     "can-namespace": "1.0.0",

--- a/reference-map.js
+++ b/reference-map.js
@@ -1,6 +1,0 @@
-var SimpleMap = require("can-simple-map");
-
-// this is a very simple can-map like object
-var ReferenceMap = SimpleMap.extend({});
-
-module.exports = ReferenceMap;

--- a/template-context.js
+++ b/template-context.js
@@ -1,0 +1,63 @@
+var canSymbol = require("can-symbol");
+var SimpleMap = require("can-simple-map");
+var defineLazyValue = require("can-define-lazy-value");
+var dev = require("can-log/dev/dev");
+
+var getKeyValueSymbol = canSymbol.for("can.getKeyValue"),
+	setKeyValueSymbol = canSymbol.for("can.setKeyValue");
+
+var getKeyAndParent = function(parent, key) {
+	if (key.substr(0, 6) === "scope.") {
+		key = key.substr(6);
+		parent = parent;
+	} else if (key === "*self") {
+		key = "view";
+		parent = parent;
+
+		//!steal-remove-start
+		dev.warn("{{>*self}} is deprecated. Use {{>scope.view}} instead.");
+		//!steal-remove-end
+	} else if (key.substr(0, 1) === "*") {
+		key = key.substr(1);
+		parent = parent.vars;
+
+		//!steal-remove-start
+		dev.warn("{{*" + key + "}} is deprecated. Use {{scope.vars." + key + "}} instead.");
+		//!steal-remove-end
+	}
+
+	// this is a separate block to handle scope.vars.whatever
+	if (key.substr(0, 5) === "vars.") {
+		key = key.substr(5);
+		parent = parent.vars;
+	}
+
+	return {
+		key: key,
+		parent: parent
+	};
+};
+
+var TemplateContext = SimpleMap.extend({});
+
+defineLazyValue(TemplateContext.prototype, "vars", function() {
+	return new SimpleMap({});
+});
+
+TemplateContext.prototype[getKeyValueSymbol] = function(originalKey) {
+	var keyAndParent = getKeyAndParent(this, originalKey);
+	var key = keyAndParent.key;
+	var parent = keyAndParent.parent;
+
+	return SimpleMap.prototype[getKeyValueSymbol].call(parent, key);
+};
+
+TemplateContext.prototype[setKeyValueSymbol] = function(originalKey, value) {
+	var keyAndParent = getKeyAndParent(this, originalKey);
+	var key = keyAndParent.key;
+	var parent = keyAndParent.parent || this;
+
+	return SimpleMap.prototype[setKeyValueSymbol].call(parent, key, value);
+};
+
+module.exports = TemplateContext;


### PR DESCRIPTION
Also deprecating {{*foo}} and {{>*self}}

This is the first part of https://github.com/canjs/can-stache/issues/304.