### PR TITLE
making sure properties starting with "scope" are read correctly

### DIFF
--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -63,7 +63,7 @@ assign(Scope, {
 		info.isInLegacyRefsScope = attr.substr(0, 1) === "*";
 		info.isInTemplateContext = info.isTemplateContext ||
 			info.isInLegacyRefsScope ||
-			attr.substr(0, 5) === "scope";
+			attr.substr(0, 6) === "scope.";
 		info.isContextBased = info.isInCurrentContext ||
 			info.isInParentContext ||
 			info.isCurrentContext ||

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -695,3 +695,10 @@ testHelpers.dev.devOnlyTest("using *foo should show deprecation warning", functi
 
 	QUnit.equal(teardown(), 1, "deprecation warning displayed");
 });
+
+QUnit.test("variables starting with 'scope' should not be read from templateContext (#104)", function() {
+	var map = new Map({ scope1: "this is scope1" });
+	var scope = new Scope(map);
+
+	QUnit.deepEqual(scope.peek("scope1"), "this is scope1", "scope1");
+});


### PR DESCRIPTION
closes https://github.com/canjs/can-view-scope/issues/104.