### PR TITLE
fixing getting/setting nested properties in references scope

### DIFF
--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -162,19 +162,20 @@ assign(Scope.prototype, {
 			return parent.read(attr.substr(3) || ".", options);
 		} else if (keyInfo.isCurrentContext) {
 			return observeReader.read(this._context, [], options);
-		} else if (keyInfo.isInTemplateContext) {
-			parent = this.getTemplateContext();
-
-			if (keyInfo.isTemplateContext) {
-				return { value: parent };
-			}
-
-			return {
-				value: canReflect.getKeyValue(parent._context, attr)
-			};
+		} else if (keyInfo.isTemplateContext) {
+			return { value: this.getTemplateContext() };
 		}
 
-		return this._read(observeReader.reads(attr), options, currentScopeOnly);
+		// if it's a reference scope, read from there.
+		var keyReads = observeReader.reads(attr);
+		if (keyInfo.isInTemplateContext) {
+			if (keyReads[0].key === "scope") {
+				keyReads = keyReads.slice(1);
+			}
+			return this.getTemplateContext()._read(keyReads, options, true);
+		} else {
+			return this._read(keyReads, options, currentScopeOnly);
+		}
 	},
 	// ## Scope.prototype._read
 	//

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -634,7 +634,6 @@ QUnit.test("Rendering a template with a custom scope (#55)", function() {
 	}
 });
 
-
 QUnit.test("generated refs scope is a Scope", function() {
 	var scope = new Scope({});
 	QUnit.equal(scope._parent, undefined, "scope initially has no parent");
@@ -701,4 +700,16 @@ QUnit.test("variables starting with 'scope' should not be read from templateCont
 	var scope = new Scope(map);
 
 	QUnit.deepEqual(scope.peek("scope1"), "this is scope1", "scope1");
+});
+
+QUnit.test("nested properties can be read from templateContext.vars", function() {
+	var foo = new Map({ bar: "baz" });
+
+	var map = new Map();
+	var scope = new Scope(map);
+
+	QUnit.ok(!scope.peek("scope.vars.foo.bar"), "vars.foo.bar === undefined");
+
+	scope.set("scope.vars.foo", foo);
+	QUnit.equal(scope.peek("scope.vars.foo.bar"), "baz", "vars.foo.bar === baz");
 });


### PR DESCRIPTION
closes https://github.com/canjs/can-view-scope/issues/106.