### PR TITLE
Use can-event-queue/value mixin in ScopeKeyData

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "can-cid": "^1.0.3",
     "can-construct": "^3.2.0",
     "can-define-lazy-value": "^1.0.0",
+    "can-event-queue": "^0.13.1",
     "can-key-tree": "^0.X",
     "can-log": "^0.1.0",
     "can-namespace": "1.0.0",


### PR DESCRIPTION
This mixin adds `getWhatIChange` which is needed by `can-debug`