### PR TITLE
Formalize apis

### DIFF
--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -88,7 +88,7 @@ assign(Scope.prototype, {
 
 	// ## Scope.prototype.find
 	find: function(attr) {
-		return this.read(attr, { currentScopeOnly: false });
+		return this.get(attr, { currentScopeOnly: false });
 	},
 
 	// ## Scope.prototype.read

--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -309,12 +309,10 @@ assign(Scope.prototype, {
 
 		// The **value was not found** in the scope
 		// if looking for a single key - check in can-stache-helpers
-		if (keyReads.length === 1) {
-			var helper = this.getHelper(keyReads[0].key);
+		var helper = this.getHelper(keyReads);
 
-			if (helper) {
-				return helper;
-			}
+		if (helper && helper.value) {
+			return helper;
 		}
 
 		// The **value was not found**, return `undefined` for the value.
@@ -330,16 +328,14 @@ assign(Scope.prototype, {
 
 	// ## Scope.prototype.getHelper
 	// read a helper from the templateContext or global helpers list
-	getHelper: function(key) {
-		var helper = canReflect.getKeyValue(this.templateContext.helpers, key);
+	getHelper: function(keyReads) {
+		var helper = observeReader.read(this.templateContext.helpers, keyReads, { proxyMethods: false });
 
-		if (!helper) {
-			helper = stacheHelpers[ key ];
+		if (!helper || !helper.value) {
+			helper = observeReader.read(stacheHelpers, keyReads, { proxyMethods: false });
 		}
 
-		if (helper) {
-			return { value: helper };
-		}
+		return helper;
 	},
 
 	// ## Scope.prototype.get

--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -183,6 +183,16 @@ assign(Scope.prototype, {
 
 		return this._read(keyReads, options, currentScopeOnly);
 	},
+
+	// ## Scope.prototype.getFromSpecialContext
+	getFromSpecialContext: function(key) {
+		var res = this._read(
+			[{key: key, at: false }],
+			{ special: true }
+		);
+		return res.value;
+	},
+
 	// ## Scope.prototype._read
 	//
 	_read: function(keyReads, options, currentScopeOnly) {
@@ -586,18 +596,13 @@ var specialKeywords = [
 	'event', 'viewModel','arguments'
 ];
 
-var readFromSpecialContexts = function(key) {
-	return function() {
-		return this._read(
-			[{ key: key, at: false }],
-			{ special: true }
-		).value;
-	};
-};
-
+// create getters for "special" keys
+// scope.index -> scope.getFromSpecialContext("index")
 specialKeywords.forEach(function(key) {
 	Object.defineProperty(Scope.prototype, key, {
-		get: readFromSpecialContexts(key)
+		get: function() {
+			return this.getFromSpecialContext(key);
+		}
 	});
 });
 

--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -624,7 +624,8 @@ defineLazyValue(Scope.prototype, 'root', function() {
 
 var specialKeywords = [
 	'index', 'key', 'element',
-	'event', 'viewModel','arguments'
+	'event', 'viewModel','arguments',
+	'helperOptions'
 ];
 
 // create getters for "special" keys

--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -310,10 +310,10 @@ assign(Scope.prototype, {
 		// The **value was not found** in the scope
 		// if looking for a single key - check in can-stache-helpers
 		if (keyReads.length === 1) {
-			var helperValue = stacheHelpers[ keyReads[0].key ];
+			var helper = this.getHelper(keyReads[0].key);
 
-			if (helperValue) {
-				return { value: helperValue };
+			if (helper) {
+				return helper;
 			}
 		}
 
@@ -326,6 +326,20 @@ assign(Scope.prototype, {
 			reads: currentSetReads,
 			value: undefined
 		};
+	},
+
+	// ## Scope.prototype.getHelper
+	// read a helper from the templateContext or global helpers list
+	getHelper: function(key) {
+		var helper = canReflect.getKeyValue(this.templateContext.helpers, key);
+
+		if (!helper) {
+			helper = stacheHelpers[ key ];
+		}
+
+		if (helper) {
+			return { value: helper };
+		}
 	},
 
 	// ## Scope.prototype.get

--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -176,11 +176,9 @@ assign(Scope.prototype, {
 
 			if (keyReads.length === 1) {
 				return { value: value };
-			} else if (value) {
-				return observeReader.read(value, keyReads.slice(1));
-			} else {
-				return this.getTemplateContext()._read(keyReads);
 			}
+
+			return observeReader.read(value, keyReads.slice(1));
 		}
 
 		return this._read(keyReads, options, currentScopeOnly);
@@ -418,11 +416,7 @@ assign(Scope.prototype, {
 			// key starts with "scope."
 			key = key.substr(6);
 
-			if (key.indexOf(".") < 0) {
-				return { parent: this.templateContext, how: "setKeyValue", key: key };
-			}
-
-			return { parent: this.getTemplateContext(), how: "set", key: key };
+			return { parent: this.templateContext, how: "setKeyValue", key: key };
 		}
 
 		var dotIndex = key.lastIndexOf('.'),

--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -12,6 +12,7 @@ var namespace = require('can-namespace');
 var canReflect = require("can-reflect");
 var canLog = require('can-log/dev/dev');
 var defineLazyValue = require('can-define-lazy-value');
+var stacheHelpers = require('can-stache-helpers');
 
 function Scope(context, parent, meta) {
 	// The obj that will be looked on for values.
@@ -303,6 +304,16 @@ assign(Scope.prototype, {
 			} else {
 				// Move up to the next scope.
 				currentScope = currentScope._parent;
+			}
+		}
+
+		// The **value was not found** in the scope
+		// if looking for a single key - check in can-stache-helpers
+		if (keyReads.length === 1) {
+			var helperValue = stacheHelpers[ keyReads[0].key ];
+
+			if (helperValue) {
+				return { value: helperValue };
 			}
 		}
 

--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -162,23 +162,24 @@ assign(Scope.prototype, {
 			keyRead = keyReads[0];
 			key = keyRead.key;
 
-			// default to reading from Scope.prototype values
 			value = this[ key ];
 
+			// default to reading from Scope.prototype values
+			if (typeof value !== 'undefined') {
+				if (keyRead.at) {
+					value = value.bind(this);
+				}
+
+				if (keyReads.length === 1) {
+					return { value: value };
+				}
+
+				return observeReader.read(value, keyReads.slice(1));
+			}
 			// otherwise, read from templateContext
-			value = typeof value !== 'undefined' ?
-				value :
-				this.templateContext[ key ];
-
-			if (keyRead.at) {
-				value = value.bind(this);
+			else {
+				return { value: this.getFromTemplateContext(key) };
 			}
-
-			if (keyReads.length === 1) {
-				return { value: value };
-			}
-
-			return observeReader.read(value, keyReads.slice(1));
 		}
 
 		return this._read(keyReads, options, currentScopeOnly);
@@ -191,6 +192,11 @@ assign(Scope.prototype, {
 			{ special: true }
 		);
 		return res.value;
+	},
+
+	// ## Scope.prototype.getFromTemplateContext
+	getFromTemplateContext: function(key) {
+		return this.templateContext[ key ];
 	},
 
 	// ## Scope.prototype._read

--- a/package.json
+++ b/package.json
@@ -41,15 +41,16 @@
     "can-namespace": "1.0.0",
     "can-observation": "^4.0.0-pre.8",
     "can-observation-recorder": "<2.0.0",
+    "can-queues": "<2.0.0",
     "can-reflect": "^1.6.0",
     "can-reflect-dependencies": "<2.0.0",
     "can-simple-map": "^4.0.0-pre.2",
+    "can-stache-helpers": "^1.0.0-pre.0",
     "can-stache-key": "^1.0.0-pre.5",
     "can-symbol": "^1.0.0",
     "can-util": "^3.9.5"
   },
   "devDependencies": {
-    "can-queues": "<2.0.0",
     "can-simple-observable": "^2.0.0-pre.3",
     "can-test-helpers": "^1.0.1",
     "detect-cyclic-packages": "^1.1.0",

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -877,9 +877,9 @@ QUnit.test("scope.find can be used to find a value in the first scope it exists"
 		.add(b)
 		.add(a);
 
-	QUnit.equal(scope.find("a").value, "a", "a");
-	QUnit.equal(scope.find("b").value, "b", "b");
-	QUnit.equal(scope.find("c").value, "c", "c");
+	QUnit.equal(scope.find("a"), "a", "a");
+	QUnit.equal(scope.find("b"), "b", "b");
+	QUnit.equal(scope.find("c"), "c", "c");
 });
 
 QUnit.test("scope.read should not walk up normal scopes by default", function() {

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -975,3 +975,25 @@ QUnit.test("read checks templateContext helpers then global helpers after checki
 	delete canStacheHelpers.localHelperFunction;
 	canReflect.setKeyValue(scope.templateContext.helpers, "localHelperFunction", undefined);
 });
+
+QUnit.test("read can handle objects stored on helpers", function() {
+	var scope = new Scope();
+
+	var fakeConsole = {
+		log: function() {
+			return "fakeConsole.log";
+		},
+		warn: function() {
+			return "fakeConsole.warn";
+		}
+	};
+	canStacheHelpers.console = fakeConsole;
+
+	var readConsoleLog = scope.read('console.log').value;
+	QUnit.deepEqual(readConsoleLog(), 'fakeConsole.log', 'fakeConsole.log');
+
+	var readConsoleWarn = scope.read('console.warn').value;
+	QUnit.deepEqual(readConsoleWarn(), 'fakeConsole.warn', 'fakeConsole.warn');
+
+	delete canStacheHelpers.console;
+});

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -11,6 +11,7 @@ var SimpleMap = require('can-simple-map');
 var SimpleObservable = require('can-simple-observable');
 var ObservationRecorder = require('can-observation-recorder');
 var canReflectDeps = require('can-reflect-dependencies');
+var canStacheHelpers = require('can-stache-helpers');
 
 QUnit.module('can/view/scope');
 
@@ -928,4 +929,28 @@ QUnit.test("reading using ../ when there is no parent returns undefined", functi
 	} catch(e) {
 		QUnit.ok(false, 'error occured: ' + e);
 	}
+});
+
+QUnit.test("read checks can-stache-helpers after checking the scope", function() {
+	var map = {
+		scopeFunction: function() {
+			return 'scopeFunction return value';
+		}
+	};
+
+	var helperFunction = function() {
+		return 'helperFunction return value';
+	};
+
+	canStacheHelpers.helperFunction = helperFunction;
+
+	var scope = new Scope(map);
+
+	var readScopeFunction = scope.read("scopeFunction").value;
+	QUnit.deepEqual(readScopeFunction(), "scopeFunction return value", "scopeFunction");
+
+	var readHelperFunction = scope.read("helperFunction").value;
+	QUnit.deepEqual(readHelperFunction(), "helperFunction return value", "helperFunction");
+
+	delete canStacheHelpers.helperFunction;
 });


### PR DESCRIPTION
Adding `getHelper` (using `can-stache-helpers`), `getFromSpecialContext`, `getFromTemplateContext`.

This also makes `scope.find` useful.