### PR TITLE
allowing using scope.helper. to read from global helpers

### DIFF
--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -997,3 +997,29 @@ QUnit.test("read can handle objects stored on helpers", function() {
 
 	delete canStacheHelpers.console;
 });
+
+QUnit.test("scope.helpers can be used to read a helper that conflicts with a property in the scope", function() {
+	var map = {
+		myIf: function() {
+			return 'map.myIf';
+		}
+	};
+
+	var myIf = function() {
+		return 'global.myIf';
+	};
+
+	var scope = new Scope(map);
+
+	// register helper function that conflicts with scope function
+	canStacheHelpers.myIf = myIf;
+
+	var localIf = scope.read('myIf').value;
+	QUnit.deepEqual(localIf(), 'map.myIf', 'scope function');
+
+	var globalIf = scope.read('scope.helpers.myIf').value;
+	QUnit.deepEqual(globalIf(), 'global.myIf', 'global function');
+
+	// clean up
+	delete canStacheHelpers.myIf;
+});


### PR DESCRIPTION
This allows you to use `{{#scope.helpers.each(...)}}` in cases where there is an `each` function on your context. This is the last piece of https://github.com/canjs/can-stache/issues/401.