### PR TITLE
Adding `thisArg` to _read and ScopeKeyData

### DIFF
--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -144,7 +144,11 @@ assign(Scope.prototype, {
 				return observeReader.read(parent._context, [], options);
 			}
 
-			return parent.read(attr.substr(3) || ".", options);
+			var parentValue = parent.read(attr.substr(3) || ".", options);
+
+			return assign( parentValue, {
+				thisArg: parentValue.thisArg || parent._context
+			});
 		} else if (keyInfo.isCurrentContext) {
 			return observeReader.read(this._context, [], options);
 		} else if (keyInfo.isScope) {
@@ -163,11 +167,9 @@ assign(Scope.prototype, {
 				readValue = this.getFromTemplateContext(attr.slice(6), options);
 			}
 
-			return {
-				value: readValue.value,
-				reads: keyReads.slice(1),
-				rootObserve: this
-			};
+			return assign( readValue, {
+				thisArg: keyReads.length > 1 ? readValue.parent : undefined
+			});
 		}
 
 		return this._read(keyReads, options, currentScopeOnly);
@@ -274,7 +276,8 @@ assign(Scope.prototype, {
 						scope: currentScope,
 						rootObserve: currentObserve,
 						value: data.value,
-						reads: currentReads
+						reads: currentReads,
+						thisArg: keyReads.length > 1 ? data.parent : undefined
 					};
 				}
 				// Otherwise, save all observables that were read.  If no value

--- a/scope-key-data.js
+++ b/scope-key-data.js
@@ -82,6 +82,7 @@ var ScopeKeyData = function(scope, key, options){
 	this.initialValue = undefined;
 	this.reads = undefined;
 	this.setRoot = undefined;
+	this.thisArg = undefined;
 	var valueDependencies = new CIDSet();
 	valueDependencies.add(observation);
 	this.dependencies = {valueDependencies: valueDependencies};
@@ -187,6 +188,7 @@ Object.assign(ScopeKeyData.prototype, {
 		this.reads = data.reads;
 		this.root = data.rootObserve;
 		this.setRoot = data.setRoot;
+		this.thisArg = data.thisArg;
 		return this.initialValue = data.value;
 	},
 	hasDependencies: function(){


### PR DESCRIPTION
This allows functions to be called with the correct context even if they
are read using `proxyMethods: false` by passing the thisArg to
Function.prototype.call or Function.prototype.apply.