### PR TITLE
cleaning up ScopeKeyData.read's name

### DIFF
--- a/scope-key-data.js
+++ b/scope-key-data.js
@@ -80,7 +80,7 @@ var ScopeKeyData = function(scope, key, options){
 
 	//!steal-remove-start
 	Object.defineProperty(this.read, "name", {
-		value: "{{" + this.key + "}}::ScopeKeyData.read",
+		value: canReflect.getName(this) + ".read",
 	});
 	Object.defineProperty(this.dispatch, "name", {
 		value: canReflect.getName(this) + ".dispatch",


### PR DESCRIPTION
This makes the name for `.read` consistent with the name for `.dispatch`.