### PR TITLE
Adding scope.vm/scope.top, deprecating scope.root, adding scope.getPathsForKey

### DIFF
--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -629,6 +629,7 @@ defineLazyValue(Scope.prototype, 'templateContext', function() {
 });
 
 defineLazyValue(Scope.prototype, 'root', function() {
+	canLog.warn('`scope.root` is deprecated. Use either `scope.top` or `scope.vm` instead.');
 	return this.getRoot();
 });
 

--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -400,6 +400,31 @@ assign(Scope.prototype, {
 		return cur._context;
 	},
 
+	// first viewModel scope
+	getViewModel: function() {
+		var vmScope = this.getScope(function(scope) {
+			return scope._meta.viewModel;
+		});
+
+		return vmScope && vmScope._context;
+	},
+
+	// _top_ viewModel scope
+	getTop: function() {
+		var top;
+
+		this.getScope(function(scope) {
+			if (scope._meta.viewModel) {
+				top = scope;
+			}
+
+			// walk entire scope tree
+			return false;
+		});
+
+		return top && top._context;
+	},
+
 	// ## Scope.prototype.getDataForScopeSet
 	// Returns an object with data needed by `.set` to figure out what to set,
 	// and how.
@@ -605,6 +630,14 @@ defineLazyValue(Scope.prototype, 'templateContext', function() {
 
 defineLazyValue(Scope.prototype, 'root', function() {
 	return this.getRoot();
+});
+
+defineLazyValue(Scope.prototype, 'vm', function() {
+	return this.getViewModel();
+});
+
+defineLazyValue(Scope.prototype, 'top', function() {
+	return this.getTop();
 });
 
 defineLazyValue(Scope.prototype, 'helpers', function() {

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -1280,3 +1280,31 @@ testHelpers.dev.devOnlyTest("scope.root deprecation warning", function() {
 
 	QUnit.equal(teardown(), 1, "deprecation warning displayed");
 });
+
+QUnit.test("scope.getPathsForKey", function() {
+	var top = {};
+	top[canSymbol.for("can.hasKey")] = function(key) {
+		return key === "name";
+	};
+
+	var vm = { name: "Ryan" };
+	var nonVm = { name: "Bianca" };
+	var notContext = { index: 0 };
+	var special = { myIndex: 0 };
+
+	var scope = new Scope(top, null, { viewModel: true })
+		.add(notContext, { notContext: true })
+		.add(vm, { viewModel: true })
+		.add(special, { special: true })
+		.add(nonVm);
+
+	var paths = scope.getPathsForKey("name");
+
+	QUnit.deepEqual(paths, {
+		"scope.vm.name": vm,
+		"scope.top.name": top,
+		"name": nonVm,
+		"../../name": vm,
+		"../../../../name": top
+	});
+});

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -1260,3 +1260,14 @@ QUnit.test("debugger is a reserved scope key for calling debugger helper", funct
 
 	delete canStacheHelpers["debugger"];
 });
+
+QUnit.test("scope.vm and scope.top", function() {
+	var scope = new Scope({ name: "foo" })
+		.add({ name: "Kevin" }, { viewModel: true }) // top
+		.add({ name: "bar" }) // intermediate
+		.add({ name: "Ryan" }, { viewModel: true }) // vm
+		.add({ name: "baz" });
+
+	QUnit.equal(scope.read("scope.vm.name").value, "Ryan", "scope.first can be used to read from the _first_ context with viewModel: true");
+	QUnit.equal(scope.read("scope.top.name").value, "Kevin", "scope.top can be used to read from the _top_ context with viewModel: true");
+});

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -1271,3 +1271,12 @@ QUnit.test("scope.vm and scope.top", function() {
 	QUnit.equal(scope.read("scope.vm.name").value, "Ryan", "scope.first can be used to read from the _first_ context with viewModel: true");
 	QUnit.equal(scope.read("scope.top.name").value, "Kevin", "scope.top can be used to read from the _top_ context with viewModel: true");
 });
+
+testHelpers.dev.devOnlyTest("scope.root deprecation warning", function() {
+	var teardown = testHelpers.dev.willWarn(/`scope.root` is deprecated/);
+
+	var scope = new Scope({ foo: "bar" });
+	scope.read("scope.root");
+
+	QUnit.equal(teardown(), 1, "deprecation warning displayed");
+});


### PR DESCRIPTION
Closes https://github.com/canjs/can-view-scope/issues/159.