### PR TITLE
preventing in operator errors if scope._context is not an object

### DIFF
--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -447,7 +447,7 @@ assign(Scope.prototype, {
 			// `notContext` and `special` contexts can't be read using `../`
 			var canBeRead = !scope._meta.special &&  !scope._meta.notContext;
 
-			if (canBeRead && canReflect.hasKey(scope._context, normalizedKey)) {
+			if (canBeRead && typeof scope._context === "object" && canReflect.hasKey(scope._context, normalizedKey)) {
 				paths[cur + normalizedKey] = scope._context;
 			}
 

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -1296,6 +1296,7 @@ QUnit.test("scope.getPathsForKey", function() {
 		.add(notContext, { notContext: true })
 		.add(vm, { viewModel: true })
 		.add(special, { special: true })
+		.add(true)
 		.add(nonVm);
 
 	var paths = scope.getPathsForKey("name");
@@ -1304,7 +1305,7 @@ QUnit.test("scope.getPathsForKey", function() {
 		"scope.vm.name": vm,
 		"scope.top.name": top,
 		"name": nonVm,
-		"../../name": vm,
-		"../../../../name": top
+		"../../../name": vm,
+		"../../../../../name": top
 	});
 });


### PR DESCRIPTION
Prevents
> Cannot use 'in' operator to search for '../foo' in true