### PR TITLE
fixing getPathsForKey to work with functions and making read return parentHasKey data

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "can-simple-map": "^4.0.0",
     "can-single-reference": "^1.0.0",
     "can-stache-helpers": "^1.0.0",
-    "can-stache-key": "^1.0.0",
+    "can-stache-key": "^1.2.0",
     "can-symbol": "^1.0.0"
   },
   "devDependencies": {

--- a/scope-key-data.js
+++ b/scope-key-data.js
@@ -96,6 +96,7 @@ var ScopeKeyData = function(scope, key, options){
 	this.reads = undefined;
 	this.setRoot = undefined;
 	this.thisArg = undefined;
+	this.parentHasKey = undefined;
 	var valueDependencies = new Set();
 	valueDependencies.add(observation);
 	this.dependencies = {valueDependencies: valueDependencies};
@@ -235,6 +236,7 @@ Object.assign(ScopeKeyData.prototype, {
 		this.root = data.rootObserve;
 		this.setRoot = data.setRoot;
 		this.thisArg = data.thisArg;
+		this.parentHasKey = data.parentHasKey;
 		return this.initialValue = data.value;
 	},
 	hasDependencies: function(){


### PR DESCRIPTION
Also re-ordering paths by "specificity" (so scope.vm.prop is suggested before
../../prop).

Part of https://github.com/canjs/can-stache/issues/529 and https://github.com/canjs/can-stache/issues/519.