### PR TITLE
unremoving scope.getPathsforKey in production

### DIFF
--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -427,9 +427,7 @@ assign(Scope.prototype, {
 
 	// ## Scope.prototype.getPathsForKey
 	// Finds all paths that will return a value for a specific key
-	// NOTE: this is for development purposes only and is removed in production
 	getPathsForKey: function getPathsForKey(key) {
-		//!steal-remove-start
 		var paths = {};
 
 		var getKeyDefinition = function(obj, key) {
@@ -495,7 +493,6 @@ assign(Scope.prototype, {
 		});
 
 		return paths;
-		//!steal-remove-end
 	},
 
 	// ## Scope.prototype.hasKey


### PR DESCRIPTION
Closes https://github.com/canjs/can-view-scope/issues/171.

Will follow up with another PR that re-removes this once the other places that use it in production are corrected.