### PR TITLE
Run tests in production mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "preversion": "npm test",
     "postpublish": "git push --tags && git push",
-    "testee": "testee test/test.html --browsers firefox",
+    "testee": "testee test/test.html test/test-production.html --browsers firefox",
     "test": "npm run detect-cycle && npm run jshint && npm run testee",
     "jshint": "jshint ./*.js test/*.js --config",
     "release:pre": "npm version prerelease && npm publish --tag pre",
@@ -56,7 +56,7 @@
     "can-test-helpers": "^1.0.1",
     "detect-cyclic-packages": "^1.1.0",
     "jshint": "^2.9.1",
-    "steal": "^1.0.1",
+    "steal": "^1.12.0",
     "steal-qunit": "^1.0.0",
     "testee": "^0.7.0"
   }

--- a/scope-key-data.js
+++ b/scope-key-data.js
@@ -196,10 +196,12 @@ Object.assign(ScopeKeyData.prototype, {
 				this.reads[ this.reads.length - 1 ].key,
 				this
 			);
+			//!steal-remove-end
 
 			// update thisArg and add new dependency
 			this.thisArg = data.parent;
 
+			//!steal-remove-start
 			canReflectDeps.addMutatedBy(
 				// for properties like foo.bar add the dependency to foo
 				this.thisArg || this.root,

--- a/test/remove-dev-code.js
+++ b/test/remove-dev-code.js
@@ -1,0 +1,34 @@
+var loader = require('@loader');
+
+var translate = loader.translate;
+loader.translate = function(load) {
+	if(this.isEnv("production")) {
+		load.source = clean(load.source, {});
+	}
+
+	return translate.apply(this, arguments);
+};
+
+function clean(original, options) {
+	var result = original;
+	var removeTags = options.removeTags || [];
+
+	if (!options.dev) {
+		removeTags.push("steal-remove");
+	}
+
+	removeTags.forEach(function(tag) {
+		result = result.replace(makeTagRegEx(tag), "");
+	});
+
+	return result;
+}
+
+function makeTagRegEx(tag) {
+	return new RegExp(
+		"(\\s?)//!(\\s?)" + tag + "-start((.|\n)*?)//!(\\s?)" + tag + "-end",
+		"gim"
+	);
+}
+
+clean.makeTagRegEx = makeTagRegEx;

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -1280,7 +1280,7 @@ testHelpers.dev.devOnlyTest("scope.root deprecation warning", function() {
 	QUnit.equal(teardown(), 1, "deprecation warning displayed");
 });
 
-QUnit.test("scope.getPathsForKey", function() {
+testHelpers.dev.devOnlyTest("scope.getPathsForKey", function() {
 	var top = {};
 	top[canSymbol.for("can.hasKey")] = function(key) {
 		return key === "name";
@@ -1309,7 +1309,7 @@ QUnit.test("scope.getPathsForKey", function() {
 	});
 });
 
-QUnit.test("scope.getPathsForKey works for functions", function() {
+testHelpers.dev.devOnlyTest("scope.getPathsForKey works for functions", function() {
 	var top = { name: function() { return "Christopher"; } };
 	var vm = { name: function() { return "Ryan"; } };
 	var nonVm = { name: function() { return "Bianca"; } };

--- a/test/test-production.html
+++ b/test/test-production.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>can-view-scope</title>
+<script>
+	steal = {
+		configDependencies: ["test/remove-dev-code"]
+	}
+</script>
+<script src="../node_modules/steal/steal.js"
+	data-env="production"
+	data-load-bundles="false"
+	data-main="can-view-scope/test/scope-test"></script>
+<div id="qunit-fixture"></div>


### PR DESCRIPTION
This runs the test in production mode by implementing the
steal-remove-start cleaning as a steal hook. So now the tests run in dev
and production mode.

This fixes the underlying cause of
https://github.com/stealjs/steal-tools/issues/1015#issuecomment-395889829
as well.