### PR TITLE
Set can-observation._value instead of .value

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -26,6 +26,7 @@
 		"Map": true
 	},
 	"strict": false,
+	"validthis": true,
 	"curly": true,
 	"eqeqeq": true,
 	"freeze": true,

--- a/scope-key-data.js
+++ b/scope-key-data.js
@@ -106,6 +106,14 @@ var ScopeKeyData = function(scope, key, options){
 
 valueEventBindings(ScopeKeyData.prototype);
 
+function fastOnBoundSet_Value() {
+	this._value = this.newVal;
+}
+
+function fastOnBoundSetValue() {
+	this.value = this.newVal;
+}
+
 Object.assign(ScopeKeyData.prototype, {
 	constructor: ScopeKeyData,
 	dispatch: function dispatch(newVal){
@@ -174,9 +182,12 @@ Object.assign(ScopeKeyData.prototype, {
 
 			return Observation.prototype.dependencyChange.apply(this, arguments);
 		};
-		observation.onBound = function(){
-			this.value = this.newVal;
-		};
+
+		if (observation.hasOwnProperty("_value")) {// can-observation 4.1+
+			observation.onBound = fastOnBoundSet_Value;
+		} else {// can-observation < 4.1
+			observation.onBound = fastOnBoundSetValue;
+		}
 	},
 	toSlowPath: function(){
 		this.observation.dependencyChange = Observation.prototype.dependencyChange;


### PR DESCRIPTION
can-observation’s value property is going to be a getter, so now the `._value` property needs to be used.

Related to https://github.com/canjs/can-observation/pull/135