### PR TITLE
Adds scope/key for scope walking

### DIFF
--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -95,10 +95,15 @@ assign(Scope, {
 		if(info.isScope) {
 			return info;
 		}
+		var firstSix = attr.substr(0, 6);
 		info.isInScope =
-			attr.substr(0, 6) === "scope." ||
-			attr.substr(0, 6) === "scope@";
+			firstSix === "scope." ||
+			firstSix === "scope@";
 		if(info.isInScope) {
+			info.remainingKey = attr.substr(6);
+			return info;
+		} else if(firstSix === "scope/") {
+			info.walkScope = true;
 			info.remainingKey = attr.substr(6);
 			return info;
 		}
@@ -338,7 +343,16 @@ assign(Scope.prototype, {
 
 			return this._walk(keyReads, options, howToRead);
 		}
-		// 1.D. Handle reading without context clues
+		// 1.D. Handle scope walking with scope/key
+		else if(keyInfo.walkScope) {
+			howToRead.shouldExit = returnFalse;
+			howToRead.shouldSkip = Scope.shouldSkipIfSpecial;
+			howToRead.shouldLookForHelper = true;
+			keyReads = stacheKey.reads(keyInfo.remainingKey);
+
+			return this._walk(keyReads, options, howToRead);
+		}
+		// 1.E. Handle reading without context clues
 		// {{foo}}
 		else {
 			keyReads = stacheKey.reads(keyInfo.remainingKey);

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -1355,6 +1355,13 @@ QUnit.test("cloneFromRef clones meta", function(){
 	QUnit.deepEqual( copyScope._meta, {variable: true});
 });
 
+QUnit.test("scope/key walks the scope", function() {
+	var scope = new Scope({foo: "bar"}).add({}).add({});
+	var value = scope.peek("scope/foo");
+
+	QUnit.equal(value, 'bar');
+});
+
 require("./variable-scope-test");
 require("./scope-set-test");
 require("./scope-key-data-test");


### PR DESCRIPTION
This adds `scope/key` as described in https://github.com/canjs/can-stache/issues/586

This provides a more convenient way to do scope walking in a template
over `scope.find(key)`.

Closes https://github.com/canjs/can-stache/issues/586