### PR TITLE
making scope/foo() walk the scope correctly before calling foo

### DIFF
--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -106,6 +106,10 @@ assign(Scope, {
 			info.walkScope = true;
 			info.remainingKey = attr.substr(6);
 			return info;
+		} else if(attr.substr(0, 7) === "@scope/") {
+			info.walkScope = true;
+			info.remainingKey = attr.substr(7);
+			return info;
 		}
 
 		info.parentContextWalkCount = 0;

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -1356,10 +1356,15 @@ QUnit.test("cloneFromRef clones meta", function(){
 });
 
 QUnit.test("scope/key walks the scope", function() {
-	var scope = new Scope({foo: "bar"}).add({}).add({});
-	var value = scope.peek("scope/foo");
+	var scope = new Scope({
+		foo: "bar",
+		baz: function() { return "quz"; }
+	}).add({}).add({});
 
-	QUnit.equal(value, 'bar');
+	var value = scope.peek("scope/foo");
+	QUnit.equal(value, "bar");
+	value = scope.peek("@scope/baz");
+	QUnit.equal(value(), "quz");
 });
 
 require("./variable-scope-test");


### PR DESCRIPTION
closes #189.