### PR TITLE
replace native Object.assign with can-assign

### DIFF
--- a/scope-key-data.js
+++ b/scope-key-data.js
@@ -114,7 +114,7 @@ function fastOnBoundSetValue() {
 	this.value = this.newVal;
 }
 
-Object.assign(ScopeKeyData.prototype, {
+assign(ScopeKeyData.prototype, {
 	constructor: ScopeKeyData,
 	dispatch: function dispatch(newVal){
 		var old = this.value;

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -548,7 +548,6 @@ testHelpers.dev.devOnlyTest("computeData dependencies", function(assert) {
 	//   |    v
 	//  computeData
 	var mapValueDependencies = canReflectDeps.getDependencyDataOf(map, "value");
-
 	assert.ok(
 		mapValueDependencies
 			.whatIChange
@@ -568,7 +567,6 @@ testHelpers.dev.devOnlyTest("computeData dependencies", function(assert) {
 	);
 
 	var computeDataDependencies = canReflect.getValueDependencies(computeData);
-
 	assert.ok(
 		computeDataDependencies
 			.valueDependencies


### PR DESCRIPTION
Fix IE 11 compatibility by using ```can-assign``` instead of native ```Object.assign``` in ```scope-key-data.js```