### PR TITLE
support a warnOnMissingKey property and temp binding on scopeKey

### DIFF
--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -691,7 +691,8 @@ assign(Scope.prototype, {
 		return res && res._context;
 	},
 	// ### scope.getTemplateContext
-	// Returns the template context
+	// Returns the template context scope
+	// This function isn't named right.
 	getTemplateContext: function() {
 		var lastScope;
 

--- a/scope-key-data.js
+++ b/scope-key-data.js
@@ -335,6 +335,9 @@ assign(ScopeKeyData.prototype, {
 		return /*this.initialValue =*/ data.value;
 	},
 	hasDependencies: function(){
+		// ScopeKeyData is unique in that when these things are read, it will temporarily bind
+		// to make sure the right value is returned. This is for can-stache.
+		// Helpers warns about a missing helper.
 		if (!this.bound) {
 			Observation.temporarilyBind(this);
 		}

--- a/scope-key-data.js
+++ b/scope-key-data.js
@@ -11,6 +11,7 @@ var canReflectDeps = require('can-reflect-dependencies');
 var valueEventBindings = require("can-event-queue/value/value");
 var stacheHelpers = require('can-stache-helpers');
 var SimpleObservable = require("can-simple-observable");
+var dev = require("can-log/dev/dev");
 
 var dispatchSymbol = canSymbol.for("can.dispatch");
 
@@ -59,6 +60,56 @@ function callMutateWithRightArgs(method, mutated, reads, mutator){
 	}
 }
 
+
+
+
+var warnOnUndefinedProperty;
+//!steal-remove-start
+if (process.env.NODE_ENV !== 'production') {
+	warnOnUndefinedProperty = function(options) {
+		if ( options.key !== "debugger" && !options.parentHasKey) {
+			var filename = options.scope.peek('scope.filename');
+			var lineNumber = options.scope.peek('scope.lineNumber');
+
+			var reads = observeReader.reads(options.key);
+			var firstKey = reads[0].key;
+			var key = reads.map(function(read) {
+				return read.key + (read.at ? "()" : "");
+			}).join(".");
+			var pathsForKey = options.scope.getPathsForKey(firstKey);
+			var paths = Object.keys( pathsForKey );
+
+			var includeSuggestions = paths.length && (paths.indexOf(firstKey) < 0);
+
+			var warning = [
+				(filename ? filename + ':' : '') +
+					(lineNumber ? lineNumber + ': ' : '') +
+					'Unable to find key "' + key + '".' +
+					(
+						includeSuggestions ?
+							" Did you mean" + (paths.length > 1 ? " one of these" : "") + "?\n" :
+							"\n"
+					)
+			];
+
+			if (includeSuggestions) {
+				paths.forEach(function(path) {
+					warning.push('\t"' + path + '" which will read from');
+					warning.push(pathsForKey[path]);
+					warning.push("\n");
+				});
+			}
+
+			warning.push("\n");
+
+			dev.warn.apply(dev,
+				warning
+			);
+		}
+	};
+}
+//!steal-remove-end
+
 // could we make this an observation first ... and have a getter for the compute?
 
 // This is a fast-path enabled Observation wrapper use many places in can-stache.
@@ -104,7 +155,7 @@ var ScopeKeyData = function(scope, key, options){
 	// things added later
 	this.fastPath = undefined;
 	this.root = undefined;
-	this.initialValue = undefined;
+	//this.initialValue = undefined;
 	this.reads = undefined;
 	this.setRoot = undefined;
 	// This is read by call expressions so it needs to be observable
@@ -270,10 +321,28 @@ assign(ScopeKeyData.prototype, {
 		this.setRoot = data.setRoot;
 		this.thisArg = data.thisArg;
 		this.parentHasKey = data.parentHasKey;
-		return this.initialValue = data.value;
+		//!steal-remove-start
+		if (process.env.NODE_ENV !== 'production') {
+			if(data.value === undefined && this.options.warnOnMissingKey === true) {
+				warnOnUndefinedProperty({
+					scope: this.startingScope,
+					key: this.key,
+					parentHasKey: data.parentHasKey
+				});
+			}
+		}
+		//!steal-remove-end
+
+		return /*this.initialValue =*/ data.value;
 	},
 	hasDependencies: function(){
+		if (!this.bound) {
+			Observation.temporarilyBind(this);
+		}
 		return canReflect.valueHasDependencies( this.observation );
+	},
+	warnOnUndefinedProperty: function(){
+
 	}
 });
 
@@ -321,6 +390,19 @@ Object.defineProperty(ScopeKeyData.prototype, "compute", {
 			configurable: false
 		});
 		return compute;
+	},
+	configurable: true
+});
+
+Object.defineProperty(ScopeKeyData.prototype, "initialValue", {
+	get: function(){
+		if (!this.bound) {
+			Observation.temporarilyBind(this);
+		}
+		return this.get();
+	},
+	set: function(){
+		throw new Error("initialValue should not be set");
 	},
 	configurable: true
 });

--- a/scope-key-data.js
+++ b/scope-key-data.js
@@ -155,7 +155,6 @@ var ScopeKeyData = function(scope, key, options){
 	// things added later
 	this.fastPath = undefined;
 	this.root = undefined;
-	//this.initialValue = undefined;
 	this.reads = undefined;
 	this.setRoot = undefined;
 	// This is read by call expressions so it needs to be observable
@@ -340,9 +339,6 @@ assign(ScopeKeyData.prototype, {
 			Observation.temporarilyBind(this);
 		}
 		return canReflect.valueHasDependencies( this.observation );
-	},
-	warnOnUndefinedProperty: function(){
-
 	}
 });
 

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -846,8 +846,8 @@ QUnit.test("ScopeKeyData can.valueHasDependencies", function(){
 	var age = base.computeData('age');
 
 
-	QUnit.equal(canReflect.valueHasDependencies(age), undefined, "undefined");
-	canReflect.onValue(age, function(){});
+	//QUnit.equal(canReflect.valueHasDependencies(age), undefined, "undefined");
+	//canReflect.onValue(age, function(){});
 
 	QUnit.equal(canReflect.valueHasDependencies(age), true, "undefined");
 });


### PR DESCRIPTION
This supports lazy reading of values.  This is needed to make something like `{{# and(this.first, this.second) }}` not actually read `this.second` if `this.first` is false.

This makes `scopeKeyData.initialValue` bind if the observable is not already bound.

This is going to be used by https://github.com/canjs/can-stache/pull/632, which will only look at `initialValue` if it absolutely needs to.  If `initialValue` is read, then the binding will happen.

Ideally, `initialValue` would not need to be looked at.  We would wait until everything is built out and `can-view-live` binds, but there are places like figuring out if a function or not where this is necessary.