### PR TITLE
removing functions added by can-event-queue from LetContext.prototype

### DIFF
--- a/can-view-scope.js
+++ b/can-view-scope.js
@@ -18,7 +18,7 @@ var canReflect = require("can-reflect");
 var canLog = require('can-log/dev/dev');
 var defineLazyValue = require('can-define-lazy-value');
 var stacheHelpers = require('can-stache-helpers');
-var SimpleMap = require('can-simple-map');
+var LetContext = require('./let-context');
 
 
 // ## Helpers
@@ -29,10 +29,6 @@ function canHaveProperties(obj){
 function returnFalse(){
 	return false;
 }
-
-// ### LetContext
-// Instances of this are used to create a `let` variable context.
-var LetContext = SimpleMap.extend("LetContext",{});
 
 // ## Scope
 // Represents a node in the scope tree.

--- a/let-context.js
+++ b/let-context.js
@@ -1,0 +1,52 @@
+var SimpleMap = require('can-simple-map');
+
+// ### LetContext
+// Instances of this are used to create a `let` variable context.
+
+// Like Object.create, but only keeps Symbols and properties in `propertiesToKeep`
+function objectCreateWithSymbolsAndSpecificProperties(obj, propertiesToKeep) {
+	var newObj = {};
+
+	// copy over all Symbols from obj
+	if ("getOwnPropertySymbols" in Object) {
+		Object.getOwnPropertySymbols(obj).forEach(function(key) {
+			newObj[key] = obj[key];
+		});
+	}
+
+	// copy over specific properties from obj (also fake Symbols properties for IE support);
+	Object.getOwnPropertyNames(obj).forEach(function(key) {
+		if (propertiesToKeep.indexOf(key) >= 0 || key.indexOf("@@symbol") === 0) {
+			newObj[key] = obj[key];
+		}
+	});
+
+	return Object.create(newObj);
+}
+
+var LetContext = SimpleMap.extend("LetContext", {});
+LetContext.prototype = objectCreateWithSymbolsAndSpecificProperties(SimpleMap.prototype, [
+	// SimpleMap properties
+	"setup",
+	"attr",
+	"serialize",
+	"get",
+	"set",
+	"log",
+	// required by SimpleMap properties
+	"dispatch",
+	// Construct properties (not added by can-event-queue)
+	"constructorExtends",
+	"newInstance",
+	"_inherit",
+	"_defineProperty",
+	"_overwrite",
+	"instance",
+	"extend",
+	"ReturnValue",
+	"setup",
+	"init"
+]);
+LetContext.prototype.constructor = LetContext;
+
+module.exports = LetContext;

--- a/test/scope-test.js
+++ b/test/scope-test.js
@@ -1379,7 +1379,15 @@ QUnit.test("able to read partials", function(assert) {
 	var result = scope.get("myPartial");
 
 	assert.equal(result, myPartial, "read the value");
+});
 
+QUnit.test("properties can shadow functions on can-event-queue/map when there is a LetContext", function(assert) {
+	var scope = new Scope({
+		one: "the one property"
+	})
+	.addLetContext();
+
+	assert.equal(scope.get("one"), "the one property", "read the value");
 });
 
 require("./variable-scope-test");


### PR DESCRIPTION
Closes https://github.com/canjs/can-view-scope/issues/204.

This changes `LetContext` to not have methods from `can-event-queue/map/map` on its prototype. This removes things like `.one`, `.addEventListener`, `.bind`, `.unbind`, etc so that these property names can be used in a `Scope`.