### PR TITLE
Handle undefined values on not found key warning

### DIFF
--- a/scope-key-data.js
+++ b/scope-key-data.js
@@ -87,6 +87,8 @@ if (process.env.NODE_ENV !== 'production') {
 			}).join(".");
 			var pathsForKey = options.scope.getPathsForKey(firstKey);
 			var paths = Object.keys( pathsForKey );
+			var firstKeyValue = options.scope.get(firstKey);
+			var value = firstKeyValue ? firstKeyValue : ""+firstKeyValue;
 
 			var includeSuggestions = paths.length && (paths.indexOf(firstKey) < 0);
 
@@ -109,9 +111,7 @@ if (process.env.NODE_ENV !== 'production') {
 				});
 			}
 
-			dev.warn.apply(dev, 
-				[warning.join("\n"), options.scope.get(firstKey)]
-			);
+			dev.warn.apply(dev, [warning.join("\n"), value]);
 		}
 	};
 }

--- a/scope-key-data.js
+++ b/scope-key-data.js
@@ -88,30 +88,34 @@ if (process.env.NODE_ENV !== 'production') {
 			var pathsForKey = options.scope.getPathsForKey(firstKey);
 			var paths = Object.keys( pathsForKey );
 			var firstKeyValue = options.scope.get(firstKey);
-			var value = firstKeyValue ? firstKeyValue : ""+firstKeyValue;
 
 			var includeSuggestions = paths.length && (paths.indexOf(firstKey) < 0);
 
 			var warning = [
 				(filename ? filename + ':' : '') +
 					(lineNumber ? lineNumber + ': ' : '') +
-					'Unable to find key "' + key + '".' +
-					(
-						includeSuggestions ?
-							' Did you mean' + (paths.length > 1 ? ' one of these' : '') + '?\n' :
-							' Found "' + firstKey + '" with value: %o\n'
-					)
+					'Unable to find key "' + key + '".'
 			];
 
 			if (includeSuggestions) {
+				warning[0] = warning[0] + ' Did you mean' + (paths.length > 1 ? ' one of these' : '') + '?\n';
 				paths.forEach(function(path) {
 					warning.push('\t"' + path + '" which will read from');
 					warning.push(pathsForKey[path]);
 					warning.push("\n");
 				});
+			} else if (firstKeyValue) {
+				warning[0] = warning[0] + ' Found "' + firstKey + '" with value: %o\n';
 			}
 
-			dev.warn.apply(dev, [warning.join("\n"), value]);
+			if (firstKeyValue) {
+				dev.warn.apply(dev, [warning.join("\n"), firstKeyValue]);
+			} else {
+				dev.warn.apply(dev,
+					warning
+				);
+			}
+
 		}
 	};
 }

--- a/test/scope-key-data-test.js
+++ b/test/scope-key-data-test.js
@@ -147,3 +147,16 @@ testHelpers.dev.devOnlyTest("Warn when key is not found and log the value of the
 	scopeKeyData.read();
 	teardown();
 });
+
+testHelpers.dev.devOnlyTest("Warn when key is not found and log the undefined value #206", function(assert) {
+	var teardown = testHelpers.dev.willWarn('Unable to find key "foo.length". Found "foo" with value: %o\n undefined');
+
+	var scope = new Scope({});
+
+	var scopeKeyData = scope.computeData("foo.length", {
+		warnOnMissingKey: true
+	});
+
+	scopeKeyData.read();
+	assert.equal(teardown(), 1, "Warning is logged with undefined");
+});

--- a/test/scope-key-data-test.js
+++ b/test/scope-key-data-test.js
@@ -149,7 +149,7 @@ testHelpers.dev.devOnlyTest("Warn when key is not found and log the value of the
 });
 
 testHelpers.dev.devOnlyTest("Don't warn when key is not defined #206", function(assert) {
-	var teardown = testHelpers.dev.willWarn(/Unable to find key "foo.length". Found "foo" with value: %o/, function(message, matched) {
+	var teardown = testHelpers.dev.willWarn('Unable to find key "foo.length', function(message, matched) {
 		assert.notOk(matched, "warning is not displayed");
 	});
 

--- a/test/scope-key-data-test.js
+++ b/test/scope-key-data-test.js
@@ -148,8 +148,10 @@ testHelpers.dev.devOnlyTest("Warn when key is not found and log the value of the
 	teardown();
 });
 
-testHelpers.dev.devOnlyTest("Warn when key is not found and log the undefined value #206", function(assert) {
-	var teardown = testHelpers.dev.willWarn('Unable to find key "foo.length". Found "foo" with value: %o\n undefined');
+testHelpers.dev.devOnlyTest("Don't warn when key is not defined #206", function(assert) {
+	var teardown = testHelpers.dev.willWarn(/Unable to find key "foo.length". Found "foo" with value: %o/, function(message, matched) {
+		assert.notOk(matched, "warning is not displayed");
+	});
 
 	var scope = new Scope({});
 
@@ -158,5 +160,5 @@ testHelpers.dev.devOnlyTest("Warn when key is not found and log the undefined va
 	});
 
 	scopeKeyData.read();
-	assert.equal(teardown(), 1, "Warning is logged with undefined");
+	teardown();
 });

--- a/test/scope-key-data-test.js
+++ b/test/scope-key-data-test.js
@@ -148,9 +148,9 @@ testHelpers.dev.devOnlyTest("Warn when key is not found and log the value of the
 	teardown();
 });
 
-testHelpers.dev.devOnlyTest("Don't warn when key is not defined #206", function(assert) {
-	var teardown = testHelpers.dev.willWarn('Unable to find key "foo.length', function(message, matched) {
-		assert.notOk(matched, "warning is not displayed");
+testHelpers.dev.devOnlyTest("Warn when key is not defined #206", function(assert) {
+	var teardown = testHelpers.dev.willWarn('Unable to find key "foo.length".', function(message, matched) {
+		assert.ok(matched, "warning is not displayed");
 	});
 
 	var scope = new Scope({});


### PR DESCRIPTION
The not found key warning message with undefined/null values will be:

undefined: `Unable to find key "foo.length". Found "foo" with value: "undefined"`
null: `Unable to find key "foo.length". Found "foo" with value: "null"`